### PR TITLE
Minor improvements in `Request`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/snapview/tungstenite-rs"
 documentation = "https://docs.rs/tungstenite/0.4.0"
 repository = "https://github.com/snapview/tungstenite-rs"
-version = "0.4.0"
+version = "0.5.0"
 
 [features]
 default = ["tls"]


### PR DESCRIPTION
Take the "best from both worlds", i.e. merge `tungstenite::handshake::client::Request` and `tokio_tungstenite::Request` into one structure to avoid confusion and code duplication and also to allow the structure to be a bit more flexible than before (previous limitation for `tokio_tungstenite::Request` and `connect_async` made it impossible to pass `String` values in the header as only `&'static str` were allowed due to `BoxFuture` requirements of `+ static`).