### PR TITLE
Derive Debugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ base64 = "0.9.0"
 byteorder = "1.1.0"
 bytes = "0.4.6"
 httparse = "1.2.3"
-input_buffer = "0.1.1"
+# Required until input_buffer has new version published with Debug derive fix present
+input_buffer = { git = "https://github.com/snapview/input_buffer" }
 log = "0.4.1"
 rand = "0.4.2"
 sha1 = "0.4.0"
@@ -32,4 +33,4 @@ optional = true
 version = "0.1.5"
 
 [dev-dependencies]
-env_logger = "0.4.3"
+env_logger = "0.5.3"

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -45,7 +45,7 @@ fn run_test(case: u32) -> Result<()> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let total = get_case_count().unwrap();
 

--- a/examples/autobahn-server.rs
+++ b/examples/autobahn-server.rs
@@ -30,7 +30,7 @@ fn handle_client(stream: TcpStream) -> Result<()> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let server = TcpListener::bind("127.0.0.1:9001").unwrap();
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -6,7 +6,7 @@ use url::Url;
 use tungstenite::{Message, connect};
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let (mut socket, response) = connect(Url::parse("ws://localhost:3012/socket").unwrap())
         .expect("Can't connect");

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -17,6 +17,7 @@ use super::machine::{HandshakeMachine, StageResult, TryParse};
 use super::{MidHandshake, HandshakeRole, ProcessingResult, convert_key};
 
 /// Client request.
+#[derive(Debug)]
 pub struct Request<'t> {
     /// `ws://` or `wss://` URL to connect to.
     pub url: Url,
@@ -67,6 +68,7 @@ impl From<Url> for Request<'static> {
 }
 
 /// Client handshake role.
+#[derive(Debug)]
 pub struct ClientHandshake<S> {
     verify_data: VerifyData,
     _marker: PhantomData<S>,
@@ -131,6 +133,7 @@ impl<S: Read + Write> HandshakeRole for ClientHandshake<S> {
 }
 
 /// Information for handshake verification.
+#[derive(Debug)]
 struct VerifyData {
     /// Accepted server key.
     accept_key: String,
@@ -183,6 +186,7 @@ impl VerifyData {
 }
 
 /// Server response.
+#[derive(Debug)]
 pub struct Response {
     /// HTTP response code of the response.
     pub code: u16,

--- a/src/handshake/headers.rs
+++ b/src/handshake/headers.rs
@@ -56,6 +56,7 @@ impl Headers {
 }
 
 /// The iterator over headers.
+#[derive(Debug)]
 pub struct HeadersIter<'name, 'headers> {
     name: &'name str,
     iter: slice::Iter<'headers, (String, Box<[u8]>)>,

--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -6,6 +6,7 @@ use error::{Error, Result};
 use util::NonBlockingResult;
 
 /// A generic handshake state machine.
+#[derive(Debug)]
 pub struct HandshakeMachine<Stream> {
     stream: Stream,
     state: HandshakeState,
@@ -98,6 +99,7 @@ impl<Stream: Read + Write> HandshakeMachine<Stream> {
 }
 
 /// The result of the round.
+#[derive(Debug)]
 pub enum RoundResult<Obj, Stream> {
     /// Round not done, I/O would block.
     WouldBlock(HandshakeMachine<Stream>),
@@ -108,6 +110,7 @@ pub enum RoundResult<Obj, Stream> {
 }
 
 /// The result of the stage.
+#[derive(Debug)]
 pub enum StageResult<Obj, Stream> {
     /// Reading round finished.
     DoneReading { result: Obj, stream: Stream, tail: Vec<u8> },
@@ -122,6 +125,7 @@ pub trait TryParse: Sized {
 }
 
 /// The handshake state.
+#[derive(Debug)]
 enum HandshakeState {
     /// Reading data from the peer.
     Reading(InputBuffer),

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -17,6 +17,7 @@ use error::Error;
 use self::machine::{HandshakeMachine, RoundResult, StageResult, TryParse};
 
 /// A WebSocket handshake.
+#[derive(Debug)]
 pub struct MidHandshake<Role: HandshakeRole> {
     role: Role,
     machine: HandshakeMachine<Role::InternalStream>,
@@ -99,6 +100,7 @@ pub trait HandshakeRole {
 
 /// Stage processing result.
 #[doc(hidden)]
+#[derive(Debug)]
 pub enum ProcessingResult<Stream, FinalResult> {
     Continue(HandshakeMachine<Stream>),
     Done(FinalResult),

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -14,6 +14,7 @@ use super::machine::{HandshakeMachine, StageResult, TryParse};
 use super::{MidHandshake, HandshakeRole, ProcessingResult, convert_key};
 
 /// Request from the client.
+#[derive(Debug)]
 pub struct Request {
     /// Path part of the URL.
     pub path: String,
@@ -90,7 +91,7 @@ impl<F> Callback for F where F: FnOnce(&Request) -> Result<Option<Vec<(String, S
 }
 
 /// Stub for callback that does nothing.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct NoCallback;
 
 impl Callback for NoCallback {
@@ -101,6 +102,7 @@ impl Callback for NoCallback {
 
 /// Server handshake role.
 #[allow(missing_copy_implementations)]
+#[derive(Debug)]
 pub struct ServerHandshake<S, C> {
     /// Callback which is called whenever the server read the request from the client and is ready
     /// to reply to it. The callback returns an optional headers which will be added to the reply

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(
     missing_docs,
     missing_copy_implementations,
+    missing_debug_implementations,
     trivial_casts, trivial_numeric_casts,
     unstable_features,
     unused_must_use,

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -14,6 +14,7 @@ use input_buffer::{InputBuffer, MIN_READ};
 use error::{Error, Result};
 
 /// A reader and writer for WebSocket frames.
+#[derive(Debug)]
 pub struct FrameSocket<Stream> {
     stream: Stream,
     in_buffer: InputBuffer,

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -12,6 +12,7 @@ mod string_collect {
 
     use error::{Error, Result};
 
+    #[derive(Debug)]
     pub struct StringCollector {
         data: String,
         incomplete: Option<utf8::Incomplete>,
@@ -81,10 +82,12 @@ mod string_collect {
 use self::string_collect::StringCollector;
 
 /// A struct representing the incomplete message.
+#[derive(Debug)]
 pub struct IncompleteMessage {
     collector: IncompleteMessageCollector,
 }
 
+#[derive(Debug)]
 enum IncompleteMessageCollector {
     Text(StringCollector),
     Binary(Vec<u8>),

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -30,6 +30,7 @@ pub enum Role {
 ///
 /// This is THE structure you want to create to be able to speak the WebSocket protocol.
 /// It may be created by calling `connect`, `accept` or `client` functions.
+#[derive(Debug)]
 pub struct WebSocket<Stream> {
     /// Server or client?
     role: Role,
@@ -396,6 +397,7 @@ impl<Stream: Read + Write> WebSocket<Stream> {
 }
 
 /// The current connection state.
+#[derive(Debug)]
 enum WebSocketState {
     /// The connection is active.
     Active,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -12,7 +12,7 @@ use std::net::TcpStream;
 use native_tls::TlsStream;
 
 /// Stream mode, either plain TCP or TLS.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum Mode {
     /// Plain mode (`ws://` URL).
     Plain,
@@ -40,6 +40,7 @@ impl<S: Read + Write + NoDelay> NoDelay for TlsStream<S> {
 }
 
 /// Stream, either plain TCP or TLS.
+#[derive(Debug)]
 pub enum Stream<S, T> {
     /// Unencrypted socket stream.
     Plain(S),


### PR DESCRIPTION
Deny missing debug and resolve resulting errors to satisfy:
https://rust-lang-nursery.github.io/api-guidelines/debuggability.html#all-public-types-implement-debug-c-debug

Requires updated input_buffer pushed to crates.io:
 - Resolved build errors by using github version of code until new version available on crates.io

Upgrade env_logger dev-dependency to v0.5.3
 - Removed unwrap call from env_logger::init()  as it is no longer needed.