### PR TITLE
frame: eliminate an unsafe when reading message data into the buffer

### DIFF
--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -5,7 +5,6 @@ use std::default::Default;
 use std::string::{String, FromUtf8Error};
 use std::result::Result as StdResult;
 use byteorder::{ByteOrder, ReadBytesExt, WriteBytesExt, NetworkEndian};
-use bytes::BufMut;
 
 use error::{Error, Result};
 use super::coding::{OpCode, Control, Data, CloseCode};
@@ -363,11 +362,9 @@ impl Frame {
         // Size is checked above, so it won't be truncated here.
         let mut data = Vec::with_capacity(length as usize);
         if length > 0 {
-            unsafe {
-                try!(cursor.read_exact(data.bytes_mut()));
-                data.advance_mut(length as usize);
-            }
+            try!(cursor.take(length).read_to_end(&mut data));
         }
+        debug_assert_eq!(data.len() as u64, length);
 
         let frame = Frame {
             finished: finished,


### PR DESCRIPTION
Since there is only one `unsafe` left outside of `frame/mask.rs`, I thought it'd be fun to try and get rid of it.

The reason for the unsafe was presumably to avoid copying or zero-initializing. This achieves the same but using only safe functions.

Note: there is no zero-initializing here because `Cursor` is "trusted" to not read from the buffer and so skips the initialization: https://github.com/rust-lang/rust/blob/master/src/libstd/io/cursor.rs#L241 (the `Take` wrapper delegates to its inner).