### PR TITLE
Add support for HTTP proxies with optional Basic Authentication

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -90,7 +90,6 @@ pub fn connect_with_config<'t, Req: Into<Request<'t>>>(
 ) -> Result<(WebSocket<AutoStream>, Response)> {
     let request: Request = request.into();
     let mode = url_mode(&request.url)?;
-    // let addrs = request.url.to_socket_addrs()?;
     let mut stream = connect_to_some(&request, mode)?;
     NoDelay::set_nodelay(&mut stream, true)?;
     client_with_config(request, stream, config)

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -21,7 +21,6 @@ use super::{MidHandshake, HandshakeRole, ProcessingResult, convert_key};
 pub struct BasicAuth {
     /// Basic Auth username
     pub username: String,
-
     /// Optional Basic Auth password
     pub password: Option<String>
 }
@@ -31,8 +30,8 @@ impl BasicAuth {
     /// in HTTP headers.
     /// Example: Username: user, Password: pass -> "Basic dXNlcjpwYXNz"
     pub fn to_header_value(&self) -> String {
-        // TODO - clean this up
-        let creds = format!("{}:{}", self.username, self.password.as_ref().unwrap_or(&"".to_string()));
+        let password = self.password.as_ref().map_or("", String::as_str);
+        let creds = format!("{}:{}", self.username, password);
         format!("Basic {}", base64::encode(&creds))
     }
 }
@@ -49,7 +48,6 @@ pub enum ProxyAuth {
 pub struct Proxy {
     /// The URL of the proxy server to connect to
     pub url: Url,
-
     /// Optional proxy authentication configuration
     pub auth: Option<ProxyAuth>,
 }
@@ -98,6 +96,24 @@ impl<'t> Request<'t> {
     }
 
     /// Sets an HTTP proxy to use when connecting to the WebSocket server
+    /// # Example
+    /// ```
+    ///    extern crate url;
+    ///
+    ///    use tungstenite::handshake::client::{BasicAuth, Proxy, ProxyAuth, Request};
+    ///    use url::Url;
+    ///
+    ///    let ws_url = Url::parse("ws://example.com/socket").unwrap();
+    ///    let mut ws_request = Request::from(ws_url);
+    ///
+    ///    ws_request.set_proxy(Proxy {
+    ///        url: "http://127.0.0.1:8899".parse().unwrap(),
+    ///        auth: Some(ProxyAuth::Basic(BasicAuth {
+    ///            username: "user".to_string(),
+    ///            password: Some("pass".to_string()),
+    ///        })),
+    ///    });
+    /// ```
     pub fn set_proxy(&mut self, proxy: Proxy) {
         self.proxy = Some(proxy);
     }


### PR DESCRIPTION
I wrote a CLI application which is sometimes used behind corporate proxies. Although the HTTP client I'm using supports configuring a proxy, this library did not, so here I am.

It currently only supports HTTP proxies (not HTTPS or SOCKS though I imagine those would be fairly easy to add) and can optionally use Basic Auth for authentication.

Halfway through implementing, I realized there's a `client` function which allows you to pass in your own `Read + Write` stream. I tried using it but found myself reimplementing a lot of what already exists inside this crate, especially the `connect_to_some` and `wrap_stream` functions.

If you feel this functionality is inappropriate to this crate and want to close this PR, that's totally okay! In that case I'll use our fork and be done with it. It just seemed like no WebSocket clients support this in an easy fashion. However I'm pretty new to interacting with proxy servers so perhaps there's a more obvious way to do what I want in these libraries (tungstenite, websocket-rs, etc.) without this change. If so, please let me know!