### PR TITLE
Make `Close` part of the `Message` enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/snapview/tungstenite-rs"
 documentation = "https://docs.rs/tungstenite/0.6.1"
 repository = "https://github.com/snapview/tungstenite-rs"
-version = "0.6.1"
+version = "0.7.0"
 
 [features]
 default = ["tls"]

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -39,7 +39,8 @@ fn run_test(case: u32) -> Result<()> {
                 socket.write_message(msg)?;
             }
             Message::Ping(_) |
-            Message::Pong(_) => {}
+            Message::Pong(_) |
+            Message::Close(_) => {}
         }
     }
 }

--- a/examples/autobahn-server.rs
+++ b/examples/autobahn-server.rs
@@ -24,7 +24,8 @@ fn handle_client(stream: TcpStream) -> Result<()> {
                 socket.write_message(msg)?;
             }
             Message::Ping(_) |
-            Message::Pong(_) => {}
+            Message::Pong(_) |
+            Message::Close(_) => {}
         }
     }
 }

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -11,7 +11,7 @@ use super::coding::{OpCode, Control, Data, CloseCode};
 use super::mask::{generate_mask, apply_mask};
 
 /// A struct representing the close command.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CloseFrame<'t> {
     /// The reason as a code.
     pub code: CloseCode,


### PR DESCRIPTION
It has been asked multiple times by other developers and mentioned in our GitHub issues, that we should support the possibility to retrieve the received the close code and also to be able to send close codes as a message (which is barely the only possible way to push messages to the sink when the one uses our `tokio-tungstenite`). We need to be able to retrieve the close messages not as an error, but as a regular message, because normal close is not considered an error and  This pull requests prepares the changes in `tungstenite-rs` for upcoming pull-request which fixes https://github.com/snapview/tokio-tungstenite/issues/45 and https://github.com/snapview/tokio-tungstenite/issues/51.

Summary:
1. Close has been added to the `Message` enum.
2. The behavior for when to return `Close` must be specified now. Previously the implementation converted some input/output errors (which happen after an attempt to read and write onto the closed connection) into the `ConnectionClosed`, so the states "the connection has just closed" (normal close) and "I'm attempting to write/read to/from the closed connection after receiving an error" were not distinguishable as well. The explicit return of `ConnectionClosed` happened either when the connection is really closed and the user tries to read/write something inside the `read_message_frame()` function or (server only) when the `write_pending()` sent all the messages and after cleaning up the queue we see that the internal state of the connection is closed. Also the error (`ConnectionClosed`) has been generated in cases when the server initiates a close frame and gets an acknowledgment. I thought a lot on how to define the behavior now and how to proceed. From one point, it makes sense to return `Message::Close` as we actually receive it, but the only concern I have is that the client may receive this message and tear down the connection immediately, because there will be "no motivation" to call `read_message()` or `write_pending()` again, which actually should be called in order to send a response to the server and let the server to close the connection. So I decided to return the `Message::Close` for the client when the connection is actually fully closed (after all acknowledgements etc). For the server it's a bit different, because someone should initiate closing of the underlying TCP connection which often happens after dropping the `WebSocket` object upon an error. I.e. if we just write a simple echo-server and simple client and both will get `Close` only when the connection is fully closed, then both apps will run forever even after sending a `Close` frame to each other, unless the user checks the reception of the `Close` frame manually and drops the underlying `WebSocket` object. So to prevent this, I left the logic "return `Error::ConnectionClosed` after the user tries to read / write to the `WebSocket` when the WS connection is logically fully closed on the server side. But then we have to decide where to return the incoming `Close` frame for the server, because if we only return `Error::ConnectionClosed`, then the user of the server side `tungstenite-rs`'s `WebSocket` connection can only get a close message after receiving the error which seems to be an obscure logic, because of that the incoming `Close` frames on the server side (when the server receives a request from the client) is returned "immediately" from the `read_message` function.
3. `translate_close()` is not required anymore, because the semantics is better defined: normal close is not an error and the user will get the `Close` message. When the user deals with the logically closed websocket connection on the server side, i.e. tries reading from the connection after `Closed` has been received, the corresponding `Error::ConnectionClosed` is returned. An attempt to read/write to the websocket after real close of the connection is an I/O error as it should be.

Suggestions or different better ideas are welcome.