### PR TITLE
Edition 2018, formatting, clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/snapview/tungstenite-rs"
 documentation = "https://docs.rs/tungstenite/0.9.1"
 repository = "https://github.com/snapview/tungstenite-rs"
 version = "0.9.1"
+edition = "2018"
 
 [features]
 default = ["tls"]

--- a/examples/callback-error.rs
+++ b/examples/callback-error.rs
@@ -1,10 +1,8 @@
-extern crate tungstenite;
-
-use std::thread::spawn;
 use std::net::TcpListener;
+use std::thread::spawn;
 
 use tungstenite::accept_hdr;
-use tungstenite::handshake::server::{Request, ErrorResponse};
+use tungstenite::handshake::server::{ErrorResponse, Request};
 use tungstenite::http::StatusCode;
 
 fn main() {

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,15 +1,11 @@
-extern crate tungstenite;
-extern crate url;
-extern crate env_logger;
-
+use tungstenite::{connect, Message};
 use url::Url;
-use tungstenite::{Message, connect};
 
 fn main() {
     env_logger::init();
 
-    let (mut socket, response) = connect(Url::parse("ws://localhost:3012/socket").unwrap())
-        .expect("Can't connect");
+    let (mut socket, response) =
+        connect(Url::parse("ws://localhost:3012/socket").unwrap()).expect("Can't connect");
 
     println!("Connected to the server");
     println!("Response HTTP code: {}", response.code);
@@ -18,11 +14,12 @@ fn main() {
         println!("* {}", header);
     }
 
-    socket.write_message(Message::Text("Hello WebSocket".into())).unwrap();
+    socket
+        .write_message(Message::Text("Hello WebSocket".into()))
+        .unwrap();
     loop {
         let msg = socket.read_message().expect("Error reading message");
         println!("Received: {}", msg);
     }
     // socket.close(None);
-
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,8 +1,5 @@
-extern crate tungstenite;
-extern crate env_logger;
-
-use std::thread::spawn;
 use std::net::TcpListener;
+use std::thread::spawn;
 
 use tungstenite::accept_hdr;
 use tungstenite::handshake::server::Request;
@@ -23,7 +20,10 @@ fn main() {
                 // Let's add an additional header to our response to the client.
                 let extra_headers = vec![
                     (String::from("MyCustomHeader"), String::from(":)")),
-                    (String::from("SOME_TUNGSTENITE_HEADER"), String::from("header_value")),
+                    (
+                        String::from("SOME_TUNGSTENITE_HEADER"),
+                        String::from("header_value"),
+                    ),
                 ];
                 Ok(Some(extra_headers))
             };

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "tungstenite-fuzz"
 version = "0.0.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,9 +11,9 @@ use std::string;
 
 use httparse;
 
-use protocol::Message;
+use crate::protocol::Message;
 
-#[cfg(feature="tls")]
+#[cfg(feature = "tls")]
 pub mod tls {
     //! TLS error wrapper module, feature-gated.
     pub use native_tls::Error;
@@ -41,7 +41,7 @@ pub enum Error {
     AlreadyClosed,
     /// Input-output error
     Io(io::Error),
-    #[cfg(feature="tls")]
+    #[cfg(feature = "tls")]
     /// TLS error
     Tls(tls::Error),
     /// Buffer capacity exhausted
@@ -64,7 +64,7 @@ impl fmt::Display for Error {
             Error::ConnectionClosed => write!(f, "Connection closed normally"),
             Error::AlreadyClosed => write!(f, "Trying to work with closed connection"),
             Error::Io(ref err) => write!(f, "IO error: {}", err),
-            #[cfg(feature="tls")]
+            #[cfg(feature = "tls")]
             Error::Tls(ref err) => write!(f, "TLS error: {}", err),
             Error::Capacity(ref msg) => write!(f, "Space limit exceeded: {}", msg),
             Error::Protocol(ref msg) => write!(f, "WebSocket protocol error: {}", msg),
@@ -82,7 +82,7 @@ impl ErrorTrait for Error {
             Error::ConnectionClosed => "A close handshake is performed",
             Error::AlreadyClosed => "Trying to read or write after getting close notification",
             Error::Io(ref err) => err.description(),
-            #[cfg(feature="tls")]
+            #[cfg(feature = "tls")]
             Error::Tls(ref err) => err.description(),
             Error::Capacity(ref msg) => msg.borrow(),
             Error::Protocol(ref msg) => msg.borrow(),
@@ -112,7 +112,7 @@ impl From<string::FromUtf8Error> for Error {
     }
 }
 
-#[cfg(feature="tls")]
+#[cfg(feature = "tls")]
 impl From<tls::Error> for Error {
     fn from(err: tls::Error) -> Self {
         Error::Tls(err)

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -4,17 +4,15 @@ use std::borrow::Cow;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 
-use base64;
 use httparse::Status;
-use httparse;
-use rand;
+use log::*;
 use url::Url;
 
-use error::{Error, Result};
-use protocol::{WebSocket, WebSocketConfig, Role};
-use super::headers::{Headers, FromHttparse, MAX_HEADERS};
+use super::headers::{FromHttparse, Headers, MAX_HEADERS};
 use super::machine::{HandshakeMachine, StageResult, TryParse};
-use super::{MidHandshake, HandshakeRole, ProcessingResult, convert_key};
+use super::{convert_key, HandshakeRole, MidHandshake, ProcessingResult};
+use crate::error::{Error, Result};
+use crate::protocol::{Role, WebSocket, WebSocketConfig};
 
 /// Client request.
 #[derive(Debug)]
@@ -80,26 +78,32 @@ impl<S: Read + Write> ClientHandshake<S> {
     pub fn start(
         stream: S,
         request: Request,
-        config: Option<WebSocketConfig>
+        config: Option<WebSocketConfig>,
     ) -> MidHandshake<Self> {
         let key = generate_key();
 
         let machine = {
             let mut req = Vec::new();
-            write!(req, "\
-                GET {path} HTTP/1.1\r\n\
-                Host: {host}\r\n\
-                Connection: upgrade\r\n\
-                Upgrade: websocket\r\n\
-                Sec-WebSocket-Version: 13\r\n\
-                Sec-WebSocket-Key: {key}\r\n",
-                host = request.get_host(), path = request.get_path(), key = key).unwrap();
+            write!(
+                req,
+                "\
+                 GET {path} HTTP/1.1\r\n\
+                 Host: {host}\r\n\
+                 Connection: upgrade\r\n\
+                 Upgrade: websocket\r\n\
+                 Sec-WebSocket-Version: 13\r\n\
+                 Sec-WebSocket-Key: {key}\r\n",
+                host = request.get_host(),
+                path = request.get_path(),
+                key = key
+            )
+            .unwrap();
             if let Some(eh) = request.extra_headers {
                 for (k, v) in eh {
-                    write!(req, "{}: {}\r\n", k, v).unwrap();
+                    writeln!(req, "{}: {}\r", k, v).unwrap();
                 }
             }
-            write!(req, "\r\n").unwrap();
+            writeln!(req, "\r").unwrap();
             HandshakeMachine::start_write(stream, req)
         };
 
@@ -113,7 +117,10 @@ impl<S: Read + Write> ClientHandshake<S> {
         };
 
         trace!("Client handshake initiated.");
-        MidHandshake { role: client, machine }
+        MidHandshake {
+            role: client,
+            machine,
+        }
     }
 }
 
@@ -121,22 +128,23 @@ impl<S: Read + Write> HandshakeRole for ClientHandshake<S> {
     type IncomingData = Response;
     type InternalStream = S;
     type FinalResult = (WebSocket<S>, Response);
-    fn stage_finished(&mut self, finish: StageResult<Self::IncomingData, Self::InternalStream>)
-        -> Result<ProcessingResult<Self::InternalStream, Self::FinalResult>>
-    {
+    fn stage_finished(
+        &mut self,
+        finish: StageResult<Self::IncomingData, Self::InternalStream>,
+    ) -> Result<ProcessingResult<Self::InternalStream, Self::FinalResult>> {
         Ok(match finish {
             StageResult::DoneWriting(stream) => {
                 ProcessingResult::Continue(HandshakeMachine::start_read(stream))
             }
-            StageResult::DoneReading { stream, result, tail, } => {
+            StageResult::DoneReading {
+                stream,
+                result,
+                tail,
+            } => {
                 self.verify_data.verify_response(&result)?;
                 debug!("Client handshake done.");
-                let websocket = WebSocket::from_partially_read(
-                    stream,
-                    tail,
-                    Role::Client,
-                    self.config.clone(),
-                );
+                let websocket =
+                    WebSocket::from_partially_read(stream, tail, Role::Client, self.config);
                 ProcessingResult::Done((websocket, result))
             }
         })
@@ -161,22 +169,37 @@ impl VerifyData {
         // header field contains a value that is not an ASCII case-
         // insensitive match for the value "websocket", the client MUST
         // _Fail the WebSocket Connection_. (RFC 6455)
-        if !response.headers.header_is_ignore_case("Upgrade", "websocket") {
-            return Err(Error::Protocol("No \"Upgrade: websocket\" in server reply".into()));
+        if !response
+            .headers
+            .header_is_ignore_case("Upgrade", "websocket")
+        {
+            return Err(Error::Protocol(
+                "No \"Upgrade: websocket\" in server reply".into(),
+            ));
         }
         // 3.  If the response lacks a |Connection| header field or the
         // |Connection| header field doesn't contain a token that is an
         // ASCII case-insensitive match for the value "Upgrade", the client
         // MUST _Fail the WebSocket Connection_. (RFC 6455)
-        if !response.headers.header_is_ignore_case("Connection", "Upgrade") {
-            return Err(Error::Protocol("No \"Connection: upgrade\" in server reply".into()));
+        if !response
+            .headers
+            .header_is_ignore_case("Connection", "Upgrade")
+        {
+            return Err(Error::Protocol(
+                "No \"Connection: upgrade\" in server reply".into(),
+            ));
         }
         // 4.  If the response lacks a |Sec-WebSocket-Accept| header field or
         // the |Sec-WebSocket-Accept| contains a value other than the
         // base64-encoded SHA-1 of ... the client MUST _Fail the WebSocket
         // Connection_. (RFC 6455)
-        if !response.headers.header_is("Sec-WebSocket-Accept", &self.accept_key) {
-            return Err(Error::Protocol("Key mismatch in Sec-WebSocket-Accept".into()));
+        if !response
+            .headers
+            .header_is("Sec-WebSocket-Accept", &self.accept_key)
+        {
+            return Err(Error::Protocol(
+                "Key mismatch in Sec-WebSocket-Accept".into(),
+            ));
         }
         // 5.  If the response includes a |Sec-WebSocket-Extensions| header
         // field and this header field indicates the use of an extension
@@ -219,7 +242,9 @@ impl TryParse for Response {
 impl<'h, 'b: 'h> FromHttparse<httparse::Response<'h, 'b>> for Response {
     fn from_httparse(raw: httparse::Response<'h, 'b>) -> Result<Self> {
         if raw.version.expect("Bug: no HTTP version") < /*1.*/1 {
-            return Err(Error::Protocol("HTTP version should be 1.1 or higher".into()));
+            return Err(Error::Protocol(
+                "HTTP version should be 1.1 or higher".into(),
+            ));
         }
         Ok(Response {
             code: raw.code.expect("Bug: no HTTP response code"),
@@ -238,8 +263,8 @@ fn generate_key() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{Response, generate_key};
     use super::super::machine::TryParse;
+    use super::{generate_key, Response};
 
     #[test]
     fn random_keys() {
@@ -262,6 +287,9 @@ mod tests {
         const DATA: &'static [u8] = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n";
         let (_, resp) = Response::try_parse(DATA).unwrap().unwrap();
         assert_eq!(resp.code, 200);
-        assert_eq!(resp.headers.find_first("Content-Type"), Some(&b"text/html"[..]));
+        assert_eq!(
+            resp.headers.find_first("Content-Type"),
+            Some(&b"text/html"[..])
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,39 +3,29 @@
     missing_docs,
     missing_copy_implementations,
     missing_debug_implementations,
-    trivial_casts, trivial_numeric_casts,
+    trivial_casts,
+    trivial_numeric_casts,
     unstable_features,
     unused_must_use,
     unused_mut,
     unused_imports,
-    unused_import_braces)]
+    unused_import_braces
+)]
 
-#[macro_use] extern crate log;
-extern crate base64;
-extern crate byteorder;
-extern crate bytes;
-extern crate httparse;
-extern crate input_buffer;
-extern crate rand;
-extern crate sha1;
-extern crate url;
-extern crate utf8;
-#[cfg(feature="tls")] extern crate native_tls;
+pub use http;
 
-pub extern crate http;
-
-pub mod error;
-pub mod protocol;
 pub mod client;
-pub mod server;
+pub mod error;
 pub mod handshake;
+pub mod protocol;
+pub mod server;
 pub mod stream;
 pub mod util;
 
-pub use client::{connect, client};
-pub use server::{accept, accept_hdr};
-pub use error::{Error, Result};
-pub use protocol::{WebSocket, Message};
-pub use handshake::HandshakeError;
-pub use handshake::client::ClientHandshake;
-pub use handshake::server::ServerHandshake;
+pub use crate::client::{client, connect};
+pub use crate::error::{Error, Result};
+pub use crate::handshake::client::ClientHandshake;
+pub use crate::handshake::server::ServerHandshake;
+pub use crate::handshake::HandshakeError;
+pub use crate::protocol::{Message, WebSocket};
+pub use crate::server::{accept, accept_hdr};

--- a/src/protocol/frame/coding.rs
+++ b/src/protocol/frame/coding.rs
@@ -1,7 +1,7 @@
 //! Various codes defined in RFC 6455.
 
+use std::convert::{From, Into};
 use std::fmt;
-use std::convert::{Into, From};
 
 /// WebSocket message opcode as in RFC 6455.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -42,8 +42,8 @@ impl fmt::Display for Data {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Data::Continue => write!(f, "CONTINUE"),
-            Data::Text     => write!(f, "TEXT"),
-            Data::Binary   => write!(f, "BINARY"),
+            Data::Text => write!(f, "TEXT"),
+            Data::Binary => write!(f, "BINARY"),
             Data::Reserved(x) => write!(f, "RESERVED_DATA_{}", x),
         }
     }
@@ -53,8 +53,8 @@ impl fmt::Display for Control {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Control::Close => write!(f, "CLOSE"),
-            Control::Ping  => write!(f, "PING"),
-            Control::Pong  => write!(f, "PONG"),
+            Control::Ping => write!(f, "PING"),
+            Control::Pong => write!(f, "PONG"),
             Control::Reserved(x) => write!(f, "RESERVED_CONTROL_{}", x),
         }
     }
@@ -71,18 +71,18 @@ impl fmt::Display for OpCode {
 
 impl Into<u8> for OpCode {
     fn into(self) -> u8 {
-        use self::Data::{Continue, Text, Binary};
         use self::Control::{Close, Ping, Pong};
+        use self::Data::{Binary, Continue, Text};
         use self::OpCode::*;
         match self {
             Data(Continue) => 0,
-            Data(Text)     => 1,
-            Data(Binary)   => 2,
+            Data(Text) => 1,
+            Data(Binary) => 2,
             Data(self::Data::Reserved(i)) => i,
 
             Control(Close) => 8,
-            Control(Ping)  => 9,
-            Control(Pong)  => 10,
+            Control(Ping) => 9,
+            Control(Pong) => 10,
             Control(self::Control::Reserved(i)) => i,
         }
     }
@@ -90,19 +90,19 @@ impl Into<u8> for OpCode {
 
 impl From<u8> for OpCode {
     fn from(byte: u8) -> OpCode {
-        use self::Data::{Continue, Text, Binary};
         use self::Control::{Close, Ping, Pong};
+        use self::Data::{Binary, Continue, Text};
         use self::OpCode::*;
         match byte {
-            0   =>   Data(Continue),
-            1   =>   Data(Text),
-            2   =>   Data(Binary),
-            i @ 3 ... 7 => Data(self::Data::Reserved(i)),
-            8   =>   Control(Close),
-            9   =>   Control(Ping),
-            10  =>   Control(Pong),
-            i @ 11 ... 15 => Control(self::Control::Reserved(i)),
-            _   =>   panic!("Bug: OpCode out of range"),
+            0 => Data(Continue),
+            1 => Data(Text),
+            2 => Data(Binary),
+            i @ 3..=7 => Data(self::Data::Reserved(i)),
+            8 => Control(Close),
+            9 => Control(Ping),
+            10 => Control(Pong),
+            i @ 11..=15 => Control(self::Control::Reserved(i)),
+            _ => panic!("Bug: OpCode out of range"),
         }
     }
 }
@@ -183,13 +183,13 @@ pub enum CloseCode {
 
 impl CloseCode {
     /// Check if this CloseCode is allowed.
-    pub fn is_allowed(&self) -> bool {
-        match *self {
-            Bad(_)      => false,
+    pub fn is_allowed(self) -> bool {
+        match self {
+            Bad(_) => false,
             Reserved(_) => false,
-            Status      => false,
-            Abnormal    => false,
-            Tls         => false,
+            Status => false,
+            Abnormal => false,
+            Tls => false,
             _ => true,
         }
     }
@@ -205,24 +205,24 @@ impl fmt::Display for CloseCode {
 impl<'t> Into<u16> for &'t CloseCode {
     fn into(self) -> u16 {
         match *self {
-           Normal         =>  1000,
-           Away           =>  1001,
-           Protocol       =>  1002,
-           Unsupported    =>  1003,
-           Status         =>  1005,
-           Abnormal       =>  1006,
-           Invalid        =>  1007,
-           Policy         =>  1008,
-           Size           =>  1009,
-           Extension      =>  1010,
-           Error          =>  1011,
-           Restart        =>  1012,
-           Again          =>  1013,
-           Tls            =>  1015,
-           Reserved(code) =>  code,
-           Iana(code)     =>  code,
-           Library(code)  =>  code,
-           Bad(code)      =>  code,
+            Normal => 1000,
+            Away => 1001,
+            Protocol => 1002,
+            Unsupported => 1003,
+            Status => 1005,
+            Abnormal => 1006,
+            Invalid => 1007,
+            Policy => 1008,
+            Size => 1009,
+            Extension => 1010,
+            Error => 1011,
+            Restart => 1012,
+            Again => 1013,
+            Tls => 1015,
+            Reserved(code) => code,
+            Iana(code) => code,
+            Library(code) => code,
+            Bad(code) => code,
         }
     }
 }
@@ -250,11 +250,11 @@ impl From<u16> for CloseCode {
             1012 => Restart,
             1013 => Again,
             1015 => Tls,
-            1...999     => Bad(code),
-            1000...2999 => Reserved(code),
-            3000...3999 => Iana(code),
-            4000...4999 => Library(code),
-            _   => Bad(code)
+            1..=999 => Bad(code),
+            1016..=2999 => Reserved(code),
+            3000..=3999 => Iana(code),
+            4000..=4999 => Library(code),
+            _ => Bad(code),
         }
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -4,18 +4,19 @@ pub mod frame;
 
 mod message;
 
-pub use self::message::Message;
 pub use self::frame::CloseFrame;
+pub use self::message::Message;
 
+use log::*;
 use std::collections::VecDeque;
-use std::io::{Read, Write, ErrorKind as IoErrorKind};
+use std::io::{ErrorKind as IoErrorKind, Read, Write};
 use std::mem::replace;
 
-use error::{Error, Result};
-use self::message::{IncompleteMessage, IncompleteMessageType};
+use self::frame::coding::{CloseCode, Control as OpCtl, Data as OpData, OpCode};
 use self::frame::{Frame, FrameCodec};
-use self::frame::coding::{OpCode, Data as OpData, Control as OpCtl, CloseCode};
-use util::NonBlockingResult;
+use self::message::{IncompleteMessage, IncompleteMessageType};
+use crate::error::{Error, Result};
+use crate::util::NonBlockingResult;
 
 /// Indicates a Client or Server role of the websocket
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -147,7 +148,6 @@ impl<Stream: Read + Write> WebSocket<Stream> {
     }
 }
 
-
 /// A context for managing WebSocket stream.
 #[derive(Debug)]
 pub struct WebSocketContext {
@@ -182,11 +182,7 @@ impl WebSocketContext {
     }
 
     /// Create a WebSocket context that manages an post-handshake stream.
-    pub fn from_partially_read(
-        part: Vec<u8>,
-        role: Role,
-        config: Option<WebSocketConfig>,
-    ) -> Self {
+    pub fn from_partially_read(part: Vec<u8>, role: Role, config: Option<WebSocketConfig>) -> Self {
         WebSocketContext {
             frame: FrameCodec::from_partially_read(part),
             ..WebSocketContext::new(role, config)
@@ -217,7 +213,7 @@ impl WebSocketContext {
             // Thus if read blocks, just let it return WouldBlock.
             if let Some(message) = self.read_message_frame(stream)? {
                 trace!("Received message {}", message);
-                return Ok(message)
+                return Ok(message);
             }
         }
     }
@@ -251,20 +247,14 @@ impl WebSocketContext {
         }
 
         let frame = match message {
-            Message::Text(data) => {
-                Frame::message(data.into(), OpCode::Data(OpData::Text), true)
-            }
-            Message::Binary(data) => {
-                Frame::message(data, OpCode::Data(OpData::Binary), true)
-            }
+            Message::Text(data) => Frame::message(data.into(), OpCode::Data(OpData::Text), true),
+            Message::Binary(data) => Frame::message(data, OpCode::Data(OpData::Binary), true),
             Message::Ping(data) => Frame::ping(data),
             Message::Pong(data) => {
                 self.pong = Some(Frame::pong(data));
-                return self.write_pending(stream)
+                return self.write_pending(stream);
             }
-            Message::Close(code) => {
-                return self.close(stream, code)
-            }
+            Message::Close(code) => return self.close(stream, code),
         };
 
         self.send_queue.push_back(frame);
@@ -342,7 +332,6 @@ impl WebSocketContext {
         Stream: Read + Write,
     {
         if let Some(mut frame) = self.frame.read_frame(stream, self.config.max_frame_size)? {
-
             // MUST be 0 unless an extension is negotiated that defines meanings
             // for non-zero values.  If a nonzero value is received and none of
             // the negotiated extensions defines the meaning of such a nonzero
@@ -351,7 +340,7 @@ impl WebSocketContext {
             {
                 let hdr = frame.header();
                 if hdr.rsv1 || hdr.rsv2 || hdr.rsv3 {
-                    return Err(Error::Protocol("Reserved bits are non-zero".into()))
+                    return Err(Error::Protocol("Reserved bits are non-zero".into()));
                 }
             }
 
@@ -364,19 +353,22 @@ impl WebSocketContext {
                     } else {
                         // The server MUST close the connection upon receiving a
                         // frame that is not masked. (RFC 6455)
-                        return Err(Error::Protocol("Received an unmasked frame from client".into()))
+                        return Err(Error::Protocol(
+                            "Received an unmasked frame from client".into(),
+                        ));
                     }
                 }
                 Role::Client => {
                     if frame.is_masked() {
                         // A client MUST close a connection if it detects a masked frame. (RFC 6455)
-                        return Err(Error::Protocol("Received a masked frame from server".into()))
+                        return Err(Error::Protocol(
+                            "Received a masked frame from server".into(),
+                        ));
                     }
                 }
             }
 
             match frame.header().opcode {
-
                 OpCode::Control(ctl) => {
                     match ctl {
                         // All control frames MUST have a payload length of 125 bytes or less
@@ -387,12 +379,10 @@ impl WebSocketContext {
                         _ if frame.payload().len() > 125 => {
                             Err(Error::Protocol("Control frame too big".into()))
                         }
-                        OpCtl::Close => {
-                            Ok(self.do_close(frame.into_close()?).map(Message::Close))
-                        }
-                        OpCtl::Reserved(i) => {
-                            Err(Error::Protocol(format!("Unknown control frame type {}", i).into()))
-                        }
+                        OpCtl::Close => Ok(self.do_close(frame.into_close()?).map(Message::Close)),
+                        OpCtl::Reserved(i) => Err(Error::Protocol(
+                            format!("Unknown control frame type {}", i).into(),
+                        )),
                         OpCtl::Ping | OpCtl::Pong if !self.state.is_active() => {
                             // No ping processing while closing.
                             Ok(None)
@@ -402,9 +392,7 @@ impl WebSocketContext {
                             self.pong = Some(Frame::pong(data.clone()));
                             Ok(Some(Message::Ping(data)))
                         }
-                        OpCtl::Pong => {
-                            Ok(Some(Message::Pong(frame.into_data())))
-                        }
+                        OpCtl::Pong => Ok(Some(Message::Pong(frame.into_data()))),
                     }
                 }
 
@@ -420,7 +408,9 @@ impl WebSocketContext {
                             if let Some(ref mut msg) = self.incomplete {
                                 msg.extend(frame.into_data(), self.config.max_message_size)?;
                             } else {
-                                return Err(Error::Protocol("Continue frame but nothing to continue".into()))
+                                return Err(Error::Protocol(
+                                    "Continue frame but nothing to continue".into(),
+                                ));
                             }
                             if fin {
                                 Ok(Some(self.incomplete.take().unwrap().complete()?))
@@ -428,11 +418,9 @@ impl WebSocketContext {
                                 Ok(None)
                             }
                         }
-                        c if self.incomplete.is_some() => {
-                            Err(Error::Protocol(
-                                format!("Received {} while waiting for more fragments", c).into()
-                            ))
-                        }
+                        c if self.incomplete.is_some() => Err(Error::Protocol(
+                            format!("Received {} while waiting for more fragments", c).into(),
+                        )),
                         OpData::Text | OpData::Binary => {
                             let msg = {
                                 let message_type = match data {
@@ -451,28 +439,27 @@ impl WebSocketContext {
                                 Ok(None)
                             }
                         }
-                        OpData::Reserved(i) => {
-                            Err(Error::Protocol(format!("Unknown data frame type {}", i).into()))
-                        }
+                        OpData::Reserved(i) => Err(Error::Protocol(
+                            format!("Unknown data frame type {}", i).into(),
+                        )),
                     }
                 }
-
             } // match opcode
-
         } else {
             // Connection closed by peer
             match replace(&mut self.state, WebSocketState::Terminated) {
                 WebSocketState::ClosedByPeer | WebSocketState::CloseAcknowledged => {
                     Err(Error::ConnectionClosed)
                 }
-                _ => {
-                    Err(Error::Protocol("Connection reset without closing handshake".into()))
-                }
+                _ => Err(Error::Protocol(
+                    "Connection reset without closing handshake".into(),
+                )),
             }
         }
     }
 
     /// Received a close frame. Tells if we need to return a close frame to the user.
+    #[allow(clippy::option_option)]
     fn do_close<'t>(&mut self, close: Option<CloseFrame<'t>>) -> Option<Option<CloseFrame<'t>>> {
         debug!("Received close frame: {:?}", close);
         match self.state {
@@ -488,7 +475,7 @@ impl WebSocketContext {
                     } else {
                         Frame::close(Some(CloseFrame {
                             code: CloseCode::Protocol,
-                            reason: "Protocol violation".into()
+                            reason: "Protocol violation".into(),
                         }))
                     }
                 } else {
@@ -518,8 +505,7 @@ impl WebSocketContext {
         Stream: Read + Write,
     {
         match self.role {
-            Role::Server => {
-            }
+            Role::Server => {}
             Role::Client => {
                 // 5.  If the data is being sent by the client, the frame(s) MUST be
                 // masked as defined in Section 5.3. (RFC 6455)
@@ -535,7 +521,9 @@ impl WebSocketContext {
                 match self.state {
                     WebSocketState::ClosedByPeer | WebSocketState::CloseAcknowledged
                         if err.kind() == IoErrorKind::ConnectionReset =>
-                            Error::ConnectionClosed,
+                    {
+                        Error::ConnectionClosed
+                    }
                     _ => Error::Io(err),
                 }
             }),
@@ -543,7 +531,6 @@ impl WebSocketContext {
         }
     }
 }
-
 
 /// The current connection state.
 #[derive(Debug)]
@@ -580,7 +567,7 @@ impl WebSocketState {
 
 #[cfg(test)]
 mod tests {
-    use super::{WebSocket, Role, Message, WebSocketConfig};
+    use super::{Message, Role, WebSocket, WebSocketConfig};
 
     use std::io;
     use std::io::Cursor;
@@ -602,57 +589,53 @@ mod tests {
         }
     }
 
-
     #[test]
     fn receive_messages() {
         let incoming = Cursor::new(vec![
-            0x89, 0x02, 0x01, 0x02,
-            0x8a, 0x01, 0x03,
-            0x01, 0x07,
-            0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20,
-            0x80, 0x06,
-            0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
-            0x82, 0x03,
-            0x01, 0x02, 0x03,
+            0x89, 0x02, 0x01, 0x02, 0x8a, 0x01, 0x03, 0x01, 0x07, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
+            0x2c, 0x20, 0x80, 0x06, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21, 0x82, 0x03, 0x01, 0x02,
+            0x03,
         ]);
         let mut socket = WebSocket::from_raw_socket(WriteMoc(incoming), Role::Client, None);
         assert_eq!(socket.read_message().unwrap(), Message::Ping(vec![1, 2]));
         assert_eq!(socket.read_message().unwrap(), Message::Pong(vec![3]));
-        assert_eq!(socket.read_message().unwrap(), Message::Text("Hello, World!".into()));
-        assert_eq!(socket.read_message().unwrap(), Message::Binary(vec![0x01, 0x02, 0x03]));
+        assert_eq!(
+            socket.read_message().unwrap(),
+            Message::Text("Hello, World!".into())
+        );
+        assert_eq!(
+            socket.read_message().unwrap(),
+            Message::Binary(vec![0x01, 0x02, 0x03])
+        );
     }
-
 
     #[test]
     fn size_limiting_text_fragmented() {
         let incoming = Cursor::new(vec![
-            0x01, 0x07,
-            0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20,
-            0x80, 0x06,
-            0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
+            0x01, 0x07, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x80, 0x06, 0x57, 0x6f, 0x72,
+            0x6c, 0x64, 0x21,
         ]);
         let limit = WebSocketConfig {
             max_message_size: Some(10),
-            .. WebSocketConfig::default()
+            ..WebSocketConfig::default()
         };
         let mut socket = WebSocket::from_raw_socket(WriteMoc(incoming), Role::Client, Some(limit));
-        assert_eq!(socket.read_message().unwrap_err().to_string(),
+        assert_eq!(
+            socket.read_message().unwrap_err().to_string(),
             "Space limit exceeded: Message too big: 7 + 6 > 10"
         );
     }
 
     #[test]
     fn size_limiting_binary() {
-        let incoming = Cursor::new(vec![
-            0x82, 0x03,
-            0x01, 0x02, 0x03,
-        ]);
+        let incoming = Cursor::new(vec![0x82, 0x03, 0x01, 0x02, 0x03]);
         let limit = WebSocketConfig {
             max_message_size: Some(2),
-            .. WebSocketConfig::default()
+            ..WebSocketConfig::default()
         };
         let mut socket = WebSocket::from_raw_socket(WriteMoc(incoming), Role::Client, Some(limit));
-        assert_eq!(socket.read_message().unwrap_err().to_string(),
+        assert_eq!(
+            socket.read_message().unwrap_err().to_string(),
             "Space limit exceeded: Message too big: 0 + 3 > 2"
         );
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,11 +1,11 @@
 //! Methods to accept an incoming WebSocket connection on a server.
 
-pub use handshake::server::ServerHandshake;
+pub use crate::handshake::server::ServerHandshake;
 
-use handshake::HandshakeError;
-use handshake::server::{Callback, NoCallback};
+use crate::handshake::server::{Callback, NoCallback};
+use crate::handshake::HandshakeError;
 
-use protocol::{WebSocket, WebSocketConfig};
+use crate::protocol::{WebSocket, WebSocketConfig};
 
 use std::io::{Read, Write};
 
@@ -18,9 +18,10 @@ use std::io::{Read, Write};
 /// If you want TLS support, use `native_tls::TlsStream` or `openssl::ssl::SslStream`
 /// for the stream here. Any `Read + Write` streams are supported, including
 /// those from `Mio` and others.
-pub fn accept_with_config<S: Read + Write>(stream: S, config: Option<WebSocketConfig>)
-    -> Result<WebSocket<S>, HandshakeError<ServerHandshake<S, NoCallback>>>
-{
+pub fn accept_with_config<S: Read + Write>(
+    stream: S,
+    config: Option<WebSocketConfig>,
+) -> Result<WebSocket<S>, HandshakeError<ServerHandshake<S, NoCallback>>> {
     accept_hdr_with_config(stream, NoCallback, config)
 }
 
@@ -30,9 +31,9 @@ pub fn accept_with_config<S: Read + Write>(stream: S, config: Option<WebSocketCo
 /// If you want TLS support, use `native_tls::TlsStream` or `openssl::ssl::SslStream`
 /// for the stream here. Any `Read + Write` streams are supported, including
 /// those from `Mio` and others.
-pub fn accept<S: Read + Write>(stream: S)
-    -> Result<WebSocket<S>, HandshakeError<ServerHandshake<S, NoCallback>>>
-{
+pub fn accept<S: Read + Write>(
+    stream: S,
+) -> Result<WebSocket<S>, HandshakeError<ServerHandshake<S, NoCallback>>> {
     accept_with_config(stream, None)
 }
 
@@ -47,7 +48,7 @@ pub fn accept<S: Read + Write>(stream: S)
 pub fn accept_hdr_with_config<S: Read + Write, C: Callback>(
     stream: S,
     callback: C,
-    config: Option<WebSocketConfig>
+    config: Option<WebSocketConfig>,
 ) -> Result<WebSocket<S>, HandshakeError<ServerHandshake<S, C>>> {
     ServerHandshake::start(stream, callback, config).handshake()
 }
@@ -57,8 +58,9 @@ pub fn accept_hdr_with_config<S: Read + Write, C: Callback>(
 /// This function does the same as `accept()` but accepts an extra callback
 /// for header processing. The callback receives headers of the incoming
 /// requests and is able to add extra headers to the reply.
-pub fn accept_hdr<S: Read + Write, C: Callback>(stream: S, callback: C)
-    -> Result<WebSocket<S>, HandshakeError<ServerHandshake<S, C>>>
-{
+pub fn accept_hdr<S: Read + Write, C: Callback>(
+    stream: S,
+    callback: C,
+) -> Result<WebSocket<S>, HandshakeError<ServerHandshake<S, C>>> {
     accept_hdr_with_config(stream, callback, None)
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,11 +4,11 @@
 //! `native_tls` or `openssl` will work as long as there is a TLS stream supporting standard
 //! `Read + Write` traits.
 
-use std::io::{Read, Write, Result as IoResult};
+use std::io::{Read, Result as IoResult, Write};
 
 use std::net::TcpStream;
 
-#[cfg(feature="tls")]
+#[cfg(feature = "tls")]
 use native_tls::TlsStream;
 
 /// Stream mode, either plain TCP or TLS.
@@ -32,7 +32,7 @@ impl NoDelay for TcpStream {
     }
 }
 
-#[cfg(feature="tls")]
+#[cfg(feature = "tls")]
 impl<S: Read + Write + NoDelay> NoDelay for TlsStream<S> {
     fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
         self.get_mut().set_nodelay(nodelay)

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::result::Result as StdResult;
 
-use error::Error;
+use crate::error::Error;
 
 /// Non-blocking IO handling.
 pub trait NonBlockingError: Sized {
@@ -40,7 +40,8 @@ pub trait NonBlockingResult {
 }
 
 impl<T, E> NonBlockingResult for StdResult<T, E>
-    where E : NonBlockingError
+where
+    E: NonBlockingError,
 {
     type Result = StdResult<Option<T>, E>;
     fn no_block(self) -> Self::Result {
@@ -49,7 +50,7 @@ impl<T, E> NonBlockingResult for StdResult<T, E>
             Err(e) => match e.into_non_blocking() {
                 Some(e) => Err(e),
                 None => Ok(None),
-            }
+            },
         }
     }
 }

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -1,13 +1,9 @@
 //! Verifies that the server returns a `ConnectionClosed` error when the connection
 //! is closedd from the server's point of view and drop the underlying tcp socket.
 
-extern crate env_logger;
-extern crate tungstenite;
-extern crate url;
-
 use std::net::TcpListener;
 use std::process::exit;
-use std::thread::{spawn, sleep};
+use std::thread::{sleep, spawn};
 use std::time::Duration;
 
 use tungstenite::{accept, connect, Error, Message};
@@ -28,14 +24,16 @@ fn test_close() {
     let client_thread = spawn(move || {
         let (mut client, _) = connect(Url::parse("ws://localhost:3012/socket").unwrap()).unwrap();
 
-        client.write_message(Message::Text("Hello WebSocket".into())).unwrap();
+        client
+            .write_message(Message::Text("Hello WebSocket".into()))
+            .unwrap();
 
         let message = client.read_message().unwrap(); // receive close from server
         assert!(message.is_close());
 
         let err = client.read_message().unwrap_err(); // now we should get ConnectionClosed
         match err {
-            Error::ConnectionClosed => { },
+            Error::ConnectionClosed => {}
             _ => panic!("unexpected error"),
         }
     });
@@ -52,7 +50,7 @@ fn test_close() {
 
     let err = client_handler.read_message().unwrap_err(); // now we should get ConnectionClosed
     match err {
-        Error::ConnectionClosed => { },
+        Error::ConnectionClosed => {}
         _ => panic!("unexpected error"),
     }
 


### PR DESCRIPTION
I have not touched any unsafe code and just left them quarantined within `#[allow]` blocks.