### PR TITLE
Keep processing incoming data even after we have initiated a close handshake.

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -396,7 +396,7 @@ impl WebSocketContext {
                     }
                 }
 
-                OpCode::Data(_) if !self.state.is_active() => {
+                OpCode::Data(_) if !self.state.can_read() => {
                     // No data processing while closing.
                     Ok(None)
                 }
@@ -552,6 +552,17 @@ impl WebSocketState {
     fn is_active(&self) -> bool {
         match *self {
             WebSocketState::Active => true,
+            _ => false,
+        }
+    }
+
+    /// Tell if we should process incoming data. Note that if we send a close frame
+    /// but the remote hasn't confirmed, they might have sent data before they receive our
+    /// close frame, so we should still pass those to client code, hence ClosedByUs is valid.
+    fn can_read(&self) -> bool {
+        match *self {
+            WebSocketState::Active     |
+            WebSocketState::ClosedByUs => true,
             _ => false,
         }
     }

--- a/tests/receive_after_init_close.rs
+++ b/tests/receive_after_init_close.rs
@@ -1,0 +1,61 @@
+//! Verifies that we can read data messages even if we have initiated a close handshake,
+//! but before we got confirmation.
+
+use std::net::TcpListener;
+use std::process::exit;
+use std::thread::{sleep, spawn};
+use std::time::Duration;
+
+use tungstenite::{accept, connect, Error, Message};
+use url::Url;
+
+#[test]
+fn test_receive_after_init_close() {
+    env_logger::init();
+
+    spawn(|| {
+        sleep(Duration::from_secs(5));
+        println!("Unit test executed too long, perhaps stuck on WOULDBLOCK...");
+        exit(1);
+    });
+
+    let server = TcpListener::bind("127.0.0.1:3013").unwrap();
+
+    let client_thread = spawn(move || {
+        let (mut client, _) = connect(Url::parse("ws://localhost:3013/socket").unwrap()).unwrap();
+
+        client
+            .write_message(Message::Text("Hello WebSocket".into()))
+            .unwrap();
+
+        let message = client.read_message().unwrap(); // receive close from server
+        assert!(message.is_close());
+
+        let err = client.read_message().unwrap_err(); // now we should get ConnectionClosed
+        match err {
+            Error::ConnectionClosed => {}
+            _ => panic!("unexpected error"),
+        }
+    });
+
+    let client_handler = server.incoming().next().unwrap();
+    let mut client_handler = accept(client_handler.unwrap()).unwrap();
+
+    client_handler.close(None).unwrap(); // send close to client
+
+    // This read should succeed even though we already initiated a close
+    let message = client_handler.read_message().unwrap();
+    assert_eq!(message.into_data(), b"Hello WebSocket");
+
+    assert!(client_handler.read_message().unwrap().is_close()); // receive acknowledgement
+
+    let err = client_handler.read_message().unwrap_err(); // now we should get ConnectionClosed
+    match err {
+        Error::ConnectionClosed => {}
+        _ => panic!("unexpected error"),
+    }
+
+    drop(client_handler);
+
+    client_thread.join().unwrap();
+}


### PR DESCRIPTION
This commit will make it so that after initiating a close handshake but before receiving confirmation from the remote. An integration test is included verifying that it works correctly.

This fixes the issue as described here: https://github.com/snapview/tokio-tungstenite/issues/69#issuecomment-530592464

Note that the websocket RFC is not specific about this. There is however no good reason for tungstenite to impose unnecessary data loss on clients.