### PR TITLE
Do not allow sending messages after sending a close frame

### DIFF
--- a/tests/no_send_after_close.rs
+++ b/tests/no_send_after_close.rs
@@ -1,0 +1,55 @@
+//! Verifies that we can read data messages even if we have initiated a close handshake,
+//! but before we got confirmation.
+
+use std::net::TcpListener;
+use std::process::exit;
+use std::thread::{sleep, spawn};
+use std::time::Duration;
+
+use tungstenite::{accept, connect, Error, Message};
+use url::Url;
+
+#[test]
+fn test_no_send_after_close() {
+    env_logger::init();
+
+    spawn(|| {
+        sleep(Duration::from_secs(5));
+        println!("Unit test executed too long, perhaps stuck on WOULDBLOCK...");
+        exit(1);
+    });
+
+    let server = TcpListener::bind("127.0.0.1:3013").unwrap();
+
+    let client_thread = spawn(move || {
+        let (mut client, _) = connect(Url::parse("ws://localhost:3013/socket").unwrap()).unwrap();
+
+        let message = client.read_message().unwrap(); // receive close from server
+        assert!(message.is_close());
+
+        let err = client.read_message().unwrap_err(); // now we should get ConnectionClosed
+        match err {
+            Error::ConnectionClosed => {}
+            _ => panic!("unexpected error: {:?}", err),
+        }
+    });
+
+    let client_handler = server.incoming().next().unwrap();
+    let mut client_handler = accept(client_handler.unwrap()).unwrap();
+
+    client_handler.close(None).unwrap(); // send close to client
+
+    let err = client_handler
+        .write_message(Message::Text("Hello WebSocket".into()));
+
+    assert!( err.is_err() );
+
+    match err.unwrap_err() {
+        Error::Protocol(s) => { assert_eq!( "Sending after closing is not allowed", s )}
+        e => panic!("unexpected error: {:?}", e),
+    }
+
+    drop(client_handler);
+
+    client_thread.join().unwrap();
+}


### PR DESCRIPTION
> The application MUST NOT send any more data frames after sending a Close frame.

src: _[The websocket RFC - section 5.5.1 Close](https://tools.ietf.org/html/rfc6455#section-5.5.1)_

Tungstenite did not comply here. This PR fixes this. There is an integration test provided that guarantees that it works.

Closes: snapview/tokio-tungstenite#67

Note that this builds upon #72, there are only 3 commits in this PR, the others are from #72.

WARNING: This is a BREAKING CHANGE