### PR TITLE
Fix typo in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ use tungstenite::server::accept;
 let server = TcpListener::bind("127.0.0.1:9001").unwrap();
 for stream in server.incoming() {
     spawn (move || {
-        let mut websocket = accept(stream.unwrap(), None).unwrap();
+        let mut websocket = accept(stream.unwrap()).unwrap();
         loop {
             let msg = websocket.read_message().unwrap();
 


### PR DESCRIPTION
The example in the main README doesn't compile:

```
error[E0061]: this function takes 1 parameter but 2 parameters were supplied
   |
   |             let mut websocket = accept(stream.unwrap(), None).unwrap();
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 parameter
```

The current [`accept()` function](https://docs.rs/tungstenite/0.9.1/tungstenite/server/fn.accept.html) seems to take only one parameter.
I'm guessing that `None` is a carry-over from `accept_hdr()`, which has a [header processing callback](https://docs.rs/tungstenite/0.9.1/tungstenite/server/fn.accept_hdr.html).
