### PR TITLE
Base HTTP-types (request, headers, response, status code, etc) on the ones from the http crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ authors = ["Alexey Galakhov"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/snapview/tungstenite-rs"
-documentation = "https://docs.rs/tungstenite/0.9.3"
+documentation = "https://docs.rs/tungstenite/0.10.0"
 repository = "https://github.com/snapview/tungstenite-rs"
-version = "0.9.3"
+version = "0.10.0"
 edition = "2018"
 
 [features]

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -3,7 +3,7 @@ use url::Url;
 
 use tungstenite::{connect, Error, Message, Result};
 
-const AGENT: &'static str = "Tungstenite";
+const AGENT: &str = "Tungstenite";
 
 fn get_case_count() -> Result<u32> {
     let (mut socket, _) = connect(Url::parse("ws://localhost:9001/getCaseCount").unwrap())?;
@@ -47,7 +47,7 @@ fn main() {
 
     let total = get_case_count().unwrap();
 
-    for case in 1..(total + 1) {
+    for case in 1..=total {
         if let Err(e) = run_test(case) {
             match e {
                 Error::Protocol(_) => {}

--- a/examples/callback-error.rs
+++ b/examples/callback-error.rs
@@ -2,19 +2,19 @@ use std::net::TcpListener;
 use std::thread::spawn;
 
 use tungstenite::accept_hdr;
-use tungstenite::handshake::server::{ErrorResponse, Request};
+use tungstenite::handshake::server::{Request, Response};
 use tungstenite::http::StatusCode;
 
 fn main() {
     let server = TcpListener::bind("127.0.0.1:3012").unwrap();
     for stream in server.incoming() {
         spawn(move || {
-            let callback = |_req: &Request| {
-                Err(ErrorResponse {
-                    error_code: StatusCode::FORBIDDEN,
-                    headers: None,
-                    body: Some("Access denied".into()),
-                })
+            let callback = |_req: &Request, _resp| {
+                let resp = Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .body(Some("Access denied".into()))
+                    .unwrap();
+                Err(resp)
             };
             accept_hdr(stream.unwrap(), callback).unwrap_err();
         });

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -8,9 +8,9 @@ fn main() {
         connect(Url::parse("ws://localhost:3012/socket").unwrap()).expect("Can't connect");
 
     println!("Connected to the server");
-    println!("Response HTTP code: {}", response.code);
+    println!("Response HTTP code: {}", response.status());
     println!("Response contains the following headers:");
-    for &(ref header, _ /*value*/) in response.headers.iter() {
+    for (ref header, _value) in response.headers() {
         println!("* {}", header);
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ use std::result;
 use std::str;
 use std::string;
 
+use http;
 use httparse;
 
 use crate::protocol::Message;
@@ -64,7 +65,7 @@ pub enum Error {
     /// Invalid URL.
     Url(Cow<'static, str>),
     /// HTTP error.
-    Http(u16),
+    Http(http::StatusCode),
     /// HTTP format error.
     HttpFormat(http::Error),
 }

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -257,13 +257,13 @@ mod tests {
         assert_eq!(k2.len(), 24);
         assert!(k1.ends_with("=="));
         assert!(k2.ends_with("=="));
-        assert!(k1[..22].find("=").is_none());
-        assert!(k2[..22].find("=").is_none());
+        assert!(k1[..22].find('=').is_none());
+        assert!(k2[..22].find('=').is_none());
     }
 
     #[test]
     fn response_parsing() {
-        const DATA: &'static [u8] = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n";
+        const DATA: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n";
         let (_, resp) = Response::try_parse(DATA).unwrap().unwrap();
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -1,70 +1,17 @@
 //! Client handshake machine.
 
-use std::borrow::Cow;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 
-use http::HeaderMap;
+use http::{HeaderMap, Request, Response, StatusCode};
 use httparse::Status;
 use log::*;
-use url::Url;
 
 use super::headers::{FromHttparse, MAX_HEADERS};
 use super::machine::{HandshakeMachine, StageResult, TryParse};
 use super::{convert_key, HandshakeRole, MidHandshake, ProcessingResult};
 use crate::error::{Error, Result};
 use crate::protocol::{Role, WebSocket, WebSocketConfig};
-
-/// Client request.
-#[derive(Debug)]
-pub struct Request<'t> {
-    /// `ws://` or `wss://` URL to connect to.
-    pub url: Url,
-    /// Extra HTTP headers to append to the request.
-    pub extra_headers: Option<Vec<(Cow<'t, str>, Cow<'t, str>)>>,
-}
-
-impl<'t> Request<'t> {
-    /// Returns the GET part of the request.
-    fn get_path(&self) -> String {
-        if let Some(query) = self.url.query() {
-            format!("{path}?{query}", path = self.url.path(), query = query)
-        } else {
-            self.url.path().into()
-        }
-    }
-
-    /// Returns the host part of the request.
-    fn get_host(&self) -> String {
-        let host = self.url.host_str().expect("Bug: URL without host");
-        if let Some(port) = self.url.port() {
-            format!("{host}:{port}", host = host, port = port)
-        } else {
-            host.into()
-        }
-    }
-
-    /// Adds a WebSocket protocol to the request.
-    pub fn add_protocol(&mut self, protocol: Cow<'t, str>) {
-        self.add_header(Cow::from("Sec-WebSocket-Protocol"), protocol);
-    }
-
-    /// Adds a custom header to the request.
-    pub fn add_header(&mut self, name: Cow<'t, str>, value: Cow<'t, str>) {
-        let mut headers = self.extra_headers.take().unwrap_or_else(Vec::new);
-        headers.push((name, value));
-        self.extra_headers = Some(headers);
-    }
-}
-
-impl From<Url> for Request<'static> {
-    fn from(value: Url) -> Self {
-        Request {
-            url: value,
-            extra_headers: None,
-        }
-    }
-}
 
 /// Client handshake role.
 #[derive(Debug)]
@@ -78,31 +25,51 @@ impl<S: Read + Write> ClientHandshake<S> {
     /// Initiate a client handshake.
     pub fn start(
         stream: S,
-        request: Request,
+        request: Request<()>,
         config: Option<WebSocketConfig>,
-    ) -> MidHandshake<Self> {
+    ) -> Result<MidHandshake<Self>> {
+        if request.method() != http::Method::GET {
+            return Err(Error::Protocol(
+                "Invalid HTTP method, only GET supported".into(),
+            ));
+        }
+
+        if request.version() < http::Version::HTTP_11 {
+            return Err(Error::Protocol(
+                "HTTP version should be 1.1 or higher".into(),
+            ));
+        }
+
+        // Check the URI scheme: only ws or wss are supported
+        let _ = crate::client::uri_mode(request.uri())?;
+
         let key = generate_key();
 
         let machine = {
             let mut req = Vec::new();
+            let uri = request.uri();
             write!(
                 req,
                 "\
-                 GET {path} HTTP/1.1\r\n\
+                 GET {path} {version:?}\r\n\
                  Host: {host}\r\n\
                  Connection: Upgrade\r\n\
                  Upgrade: websocket\r\n\
                  Sec-WebSocket-Version: 13\r\n\
                  Sec-WebSocket-Key: {key}\r\n",
-                host = request.get_host(),
-                path = request.get_path(),
+                version = request.version(),
+                host = uri
+                    .host()
+                    .ok_or_else(|| Error::Url("No host name in the URL".into()))?,
+                path = uri
+                    .path_and_query()
+                    .ok_or_else(|| Error::Url("No path/query in URL".into()))?
+                    .as_str(),
                 key = key
             )
             .unwrap();
-            if let Some(eh) = request.extra_headers {
-                for (k, v) in eh {
-                    writeln!(req, "{}: {}\r", k, v).unwrap();
-                }
+            for (k, v) in request.headers() {
+                writeln!(req, "{}: {}\r", k, v.to_str()?).unwrap();
             }
             writeln!(req, "\r").unwrap();
             HandshakeMachine::start_write(stream, req)
@@ -118,17 +85,17 @@ impl<S: Read + Write> ClientHandshake<S> {
         };
 
         trace!("Client handshake initiated.");
-        MidHandshake {
+        Ok(MidHandshake {
             role: client,
             machine,
-        }
+        })
     }
 }
 
 impl<S: Read + Write> HandshakeRole for ClientHandshake<S> {
-    type IncomingData = Response;
+    type IncomingData = Response<()>;
     type InternalStream = S;
-    type FinalResult = (WebSocket<S>, Response);
+    type FinalResult = (WebSocket<S>, Response<()>);
     fn stage_finished(
         &mut self,
         finish: StageResult<Self::IncomingData, Self::InternalStream>,
@@ -160,18 +127,19 @@ struct VerifyData {
 }
 
 impl VerifyData {
-    pub fn verify_response(&self, response: &Response) -> Result<()> {
+    pub fn verify_response(&self, response: &Response<()>) -> Result<()> {
         // 1. If the status code received from the server is not 101, the
         // client handles the response per HTTP [RFC2616] procedures. (RFC 6455)
-        if response.code != 101 {
-            return Err(Error::Http(response.code));
+        if response.status() != StatusCode::SWITCHING_PROTOCOLS {
+            return Err(Error::Http(response.status()));
         }
+        let headers = response.headers();
+
         // 2. If the response lacks an |Upgrade| header field or the |Upgrade|
         // header field contains a value that is not an ASCII case-
         // insensitive match for the value "websocket", the client MUST
         // _Fail the WebSocket Connection_. (RFC 6455)
-        if !response
-            .headers
+        if !headers
             .get("Upgrade")
             .and_then(|h| h.to_str().ok())
             .map(|h| h.eq_ignore_ascii_case("websocket"))
@@ -185,8 +153,7 @@ impl VerifyData {
         // |Connection| header field doesn't contain a token that is an
         // ASCII case-insensitive match for the value "Upgrade", the client
         // MUST _Fail the WebSocket Connection_. (RFC 6455)
-        if !response
-            .headers
+        if !headers
             .get("Connection")
             .and_then(|h| h.to_str().ok())
             .map(|h| h.eq_ignore_ascii_case("Upgrade"))
@@ -200,8 +167,7 @@ impl VerifyData {
         // the |Sec-WebSocket-Accept| contains a value other than the
         // base64-encoded SHA-1 of ... the client MUST _Fail the WebSocket
         // Connection_. (RFC 6455)
-        if !response
-            .headers
+        if !headers
             .get("Sec-WebSocket-Accept")
             .map(|h| h == &self.accept_key)
             .unwrap_or(false)
@@ -228,16 +194,7 @@ impl VerifyData {
     }
 }
 
-/// Server response.
-#[derive(Debug)]
-pub struct Response {
-    /// HTTP response code of the response.
-    pub code: u16,
-    /// Received headers.
-    pub headers: HeaderMap,
-}
-
-impl TryParse for Response {
+impl TryParse for Response<()> {
     fn try_parse(buf: &[u8]) -> Result<Option<(usize, Self)>> {
         let mut hbuffer = [httparse::EMPTY_HEADER; MAX_HEADERS];
         let mut req = httparse::Response::new(&mut hbuffer);
@@ -248,17 +205,24 @@ impl TryParse for Response {
     }
 }
 
-impl<'h, 'b: 'h> FromHttparse<httparse::Response<'h, 'b>> for Response {
+impl<'h, 'b: 'h> FromHttparse<httparse::Response<'h, 'b>> for Response<()> {
     fn from_httparse(raw: httparse::Response<'h, 'b>) -> Result<Self> {
         if raw.version.expect("Bug: no HTTP version") < /*1.*/1 {
             return Err(Error::Protocol(
                 "HTTP version should be 1.1 or higher".into(),
             ));
         }
-        Ok(Response {
-            code: raw.code.expect("Bug: no HTTP response code"),
-            headers: HeaderMap::from_httparse(raw.headers)?,
-        })
+
+        let headers = HeaderMap::from_httparse(raw.headers)?;
+
+        let mut response = Response::new(());
+        *response.status_mut() = StatusCode::from_u16(raw.code.expect("Bug: no HTTP status code"))?;
+        *response.headers_mut() = headers;
+        // TODO: httparse only supports HTTP 0.9/1.0/1.1 but not HTTP 2.0
+        // so the only valid value we could get in the response would be 1.1.
+        *response.version_mut() = http::Version::HTTP_11;
+
+        Ok(response)
     }
 }
 
@@ -295,7 +259,10 @@ mod tests {
     fn response_parsing() {
         const DATA: &'static [u8] = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n";
         let (_, resp) = Response::try_parse(DATA).unwrap().unwrap();
-        assert_eq!(resp.code, 200);
-        assert_eq!(resp.headers.get("Content-Type").unwrap(), &b"text/html"[..],);
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("Content-Type").unwrap(),
+            &b"text/html"[..],
+        );
     }
 }

--- a/src/handshake/headers.rs
+++ b/src/handshake/headers.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn headers() {
-        const DATA: &'static [u8] = b"Host: foo.com\r\n\
+        const DATA: &[u8] = b"Host: foo.com\r\n\
              Connection: Upgrade\r\n\
              Upgrade: websocket\r\n\
              \r\n";
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn headers_iter() {
-        const DATA: &'static [u8] = b"Host: foo.com\r\n\
+        const DATA: &[u8] = b"Host: foo.com\r\n\
               Sec-WebSocket-Extensions: permessage-deflate\r\n\
               Connection: Upgrade\r\n\
               Sec-WebSocket-ExtenSIONS: permessage-unknown\r\n\
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn headers_incomplete() {
-        const DATA: &'static [u8] = b"Host: foo.com\r\n\
+        const DATA: &[u8] = b"Host: foo.com\r\n\
               Connection: Upgrade\r\n\
               Upgrade: websocket\r\n";
         let hdr = HeaderMap::try_parse(DATA).unwrap();

--- a/src/handshake/headers.rs
+++ b/src/handshake/headers.rs
@@ -1,8 +1,7 @@
 //! HTTP Request and response header handling.
 
-use std::slice;
-use std::str::from_utf8;
-
+use http;
+use http::header::{HeaderMap, HeaderName, HeaderValue};
 use httparse;
 use httparse::Status;
 
@@ -12,90 +11,31 @@ use crate::error::Result;
 /// Limit for the number of header lines.
 pub const MAX_HEADERS: usize = 124;
 
-/// HTTP request or response headers.
-#[derive(Debug)]
-pub struct Headers {
-    data: Vec<(String, Box<[u8]>)>,
-}
-
-impl Headers {
-    /// Get first header with the given name, if any.
-    pub fn find_first(&self, name: &str) -> Option<&[u8]> {
-        self.find(name).next()
-    }
-
-    /// Iterate over all headers with the given name.
-    pub fn find<'headers, 'name>(&'headers self, name: &'name str) -> HeadersIter<'name, 'headers> {
-        HeadersIter {
-            name,
-            iter: self.data.iter(),
-        }
-    }
-
-    /// Check if the given header has the given value.
-    pub fn header_is(&self, name: &str, value: &str) -> bool {
-        self.find_first(name)
-            .map(|v| v == value.as_bytes())
-            .unwrap_or(false)
-    }
-
-    /// Check if the given header has the given value (case-insensitive).
-    pub fn header_is_ignore_case(&self, name: &str, value: &str) -> bool {
-        self.find_first(name)
-            .ok_or(())
-            .and_then(|val_raw| from_utf8(val_raw).map_err(|_| ()))
-            .map(|val| val.eq_ignore_ascii_case(value))
-            .unwrap_or(false)
-    }
-
-    /// Allows to iterate over available headers.
-    pub fn iter(&self) -> slice::Iter<(String, Box<[u8]>)> {
-        self.data.iter()
-    }
-}
-
-/// The iterator over headers.
-#[derive(Debug)]
-pub struct HeadersIter<'name, 'headers> {
-    name: &'name str,
-    iter: slice::Iter<'headers, (String, Box<[u8]>)>,
-}
-
-impl<'name, 'headers> Iterator for HeadersIter<'name, 'headers> {
-    type Item = &'headers [u8];
-    fn next(&mut self) -> Option<Self::Item> {
-        while let Some(&(ref name, ref value)) = self.iter.next() {
-            if name.eq_ignore_ascii_case(self.name) {
-                return Some(value);
-            }
-        }
-        None
-    }
-}
-
 /// Trait to convert raw objects into HTTP parseables.
-pub trait FromHttparse<T>: Sized {
+pub(crate) trait FromHttparse<T>: Sized {
     /// Convert raw object into parsed HTTP headers.
     fn from_httparse(raw: T) -> Result<Self>;
 }
 
-impl TryParse for Headers {
+impl<'b: 'h, 'h> FromHttparse<&'b [httparse::Header<'h>]> for HeaderMap {
+    fn from_httparse(raw: &'b [httparse::Header<'h>]) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        for h in raw {
+            headers.append(
+                HeaderName::from_bytes(h.name.as_bytes())?,
+                HeaderValue::from_bytes(h.value)?,
+            );
+        }
+
+        Ok(headers)
+    }
+}
+impl TryParse for HeaderMap {
     fn try_parse(buf: &[u8]) -> Result<Option<(usize, Self)>> {
         let mut hbuffer = [httparse::EMPTY_HEADER; MAX_HEADERS];
         Ok(match httparse::parse_headers(buf, &mut hbuffer)? {
             Status::Partial => None,
-            Status::Complete((size, hdr)) => Some((size, Headers::from_httparse(hdr)?)),
-        })
-    }
-}
-
-impl<'b: 'h, 'h> FromHttparse<&'b [httparse::Header<'h>]> for Headers {
-    fn from_httparse(raw: &'b [httparse::Header<'h>]) -> Result<Self> {
-        Ok(Headers {
-            data: raw
-                .iter()
-                .map(|h| (h.name.into(), Vec::from(h.value).into_boxed_slice()))
-                .collect(),
+            Status::Complete((size, hdr)) => Some((size, HeaderMap::from_httparse(hdr)?)),
         })
     }
 }
@@ -104,7 +44,7 @@ impl<'b: 'h, 'h> FromHttparse<&'b [httparse::Header<'h>]> for Headers {
 mod tests {
 
     use super::super::machine::TryParse;
-    use super::Headers;
+    use super::HeaderMap;
 
     #[test]
     fn headers() {
@@ -112,14 +52,10 @@ mod tests {
              Connection: Upgrade\r\n\
              Upgrade: websocket\r\n\
              \r\n";
-        let (_, hdr) = Headers::try_parse(DATA).unwrap().unwrap();
-        assert_eq!(hdr.find_first("Host"), Some(&b"foo.com"[..]));
-        assert_eq!(hdr.find_first("Upgrade"), Some(&b"websocket"[..]));
-        assert_eq!(hdr.find_first("Connection"), Some(&b"Upgrade"[..]));
-
-        assert!(hdr.header_is("upgrade", "websocket"));
-        assert!(!hdr.header_is("upgrade", "Websocket"));
-        assert!(hdr.header_is_ignore_case("upgrade", "Websocket"));
+        let (_, hdr) = HeaderMap::try_parse(DATA).unwrap().unwrap();
+        assert_eq!(hdr.get("Host").unwrap(), &b"foo.com"[..]);
+        assert_eq!(hdr.get("Upgrade").unwrap(), &b"websocket"[..]);
+        assert_eq!(hdr.get("Connection").unwrap(), &b"Upgrade"[..]);
     }
 
     #[test]
@@ -130,10 +66,10 @@ mod tests {
               Sec-WebSocket-ExtenSIONS: permessage-unknown\r\n\
               Upgrade: websocket\r\n\
               \r\n";
-        let (_, hdr) = Headers::try_parse(DATA).unwrap().unwrap();
-        let mut iter = hdr.find("Sec-WebSocket-Extensions");
-        assert_eq!(iter.next(), Some(&b"permessage-deflate"[..]));
-        assert_eq!(iter.next(), Some(&b"permessage-unknown"[..]));
+        let (_, hdr) = HeaderMap::try_parse(DATA).unwrap().unwrap();
+        let mut iter = hdr.get_all("Sec-WebSocket-Extensions").iter();
+        assert_eq!(iter.next().unwrap(), &b"permessage-deflate"[..]);
+        assert_eq!(iter.next().unwrap(), &b"permessage-unknown"[..]);
         assert_eq!(iter.next(), None);
     }
 
@@ -142,7 +78,7 @@ mod tests {
         const DATA: &'static [u8] = b"Host: foo.com\r\n\
               Connection: Upgrade\r\n\
               Upgrade: websocket\r\n";
-        let hdr = Headers::try_parse(DATA).unwrap();
+        let hdr = HeaderMap::try_parse(DATA).unwrap();
         assert!(hdr.is_none());
     }
 }

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::result::Result as StdResult;
 
-use http::{HeaderMap, StatusCode};
+use http::{HeaderMap, Request, Response, StatusCode};
 use httparse::Status;
 use log::*;
 
@@ -15,41 +15,28 @@ use super::{convert_key, HandshakeRole, MidHandshake, ProcessingResult};
 use crate::error::{Error, Result};
 use crate::protocol::{Role, WebSocket, WebSocketConfig};
 
-/// Request from the client.
-#[derive(Debug)]
-pub struct Request {
-    /// Path part of the URL.
-    pub path: String,
-    /// HTTP headers.
-    pub headers: HeaderMap,
+/// Reply to the response.
+fn reply(request: &Request<()>, extra_headers: Option<HeaderMap>) -> Result<Vec<u8>> {
+    let key = request
+        .headers()
+        .get("Sec-WebSocket-Key")
+        .ok_or_else(|| Error::Protocol("Missing Sec-WebSocket-Key".into()))?;
+    let mut reply = format!(
+        "\
+         HTTP/1.1 101 Switching Protocols\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Accept: {}\r\n",
+        convert_key(key.as_bytes())?
+    );
+    add_headers(&mut reply, extra_headers.as_ref())?;
+    Ok(reply.into())
 }
 
-impl Request {
-    /// Reply to the response.
-    pub fn reply(&self, extra_headers: Option<HeaderMap>) -> Result<Vec<u8>> {
-        let key = self
-            .headers
-            .get("Sec-WebSocket-Key")
-            .ok_or_else(|| Error::Protocol("Missing Sec-WebSocket-Key".into()))?;
-        let mut reply = format!(
-            "\
-             HTTP/1.1 101 Switching Protocols\r\n\
-             Connection: Upgrade\r\n\
-             Upgrade: websocket\r\n\
-             Sec-WebSocket-Accept: {}\r\n",
-            convert_key(key.as_bytes())?
-        );
-        add_headers(&mut reply, extra_headers)?;
-        Ok(reply.into())
-    }
-}
-
-fn add_headers(reply: &mut impl FmtWrite, extra_headers: Option<HeaderMap>) -> Result<()> {
+fn add_headers(reply: &mut impl FmtWrite, extra_headers: Option<&HeaderMap>) -> Result<()> {
     if let Some(eh) = extra_headers {
         for (k, v) in eh {
-            if let Some(k) = k {
-                writeln!(reply, "{}: {}\r", k, v.to_str()?).unwrap();
-            }
+            writeln!(reply, "{}: {}\r", k, v.to_str()?).unwrap();
         }
     }
     writeln!(reply, "\r").unwrap();
@@ -57,7 +44,7 @@ fn add_headers(reply: &mut impl FmtWrite, extra_headers: Option<HeaderMap>) -> R
     Ok(())
 }
 
-impl TryParse for Request {
+impl TryParse for Request<()> {
     fn try_parse(buf: &[u8]) -> Result<Option<(usize, Self)>> {
         let mut hbuffer = [httparse::EMPTY_HEADER; MAX_HEADERS];
         let mut req = httparse::Request::new(&mut hbuffer);
@@ -68,41 +55,29 @@ impl TryParse for Request {
     }
 }
 
-impl<'h, 'b: 'h> FromHttparse<httparse::Request<'h, 'b>> for Request {
+impl<'h, 'b: 'h> FromHttparse<httparse::Request<'h, 'b>> for Request<()> {
     fn from_httparse(raw: httparse::Request<'h, 'b>) -> Result<Self> {
         if raw.method.expect("Bug: no method in header") != "GET" {
             return Err(Error::Protocol("Method is not GET".into()));
         }
+
         if raw.version.expect("Bug: no HTTP version") < /*1.*/1 {
             return Err(Error::Protocol(
                 "HTTP version should be 1.1 or higher".into(),
             ));
         }
-        Ok(Request {
-            path: raw.path.expect("Bug: no path in header").into(),
-            headers: HeaderMap::from_httparse(raw.headers)?,
-        })
-    }
-}
 
-/// An error response sent to the client.
-#[derive(Debug)]
-pub struct ErrorResponse {
-    /// HTTP error code.
-    pub error_code: StatusCode,
-    /// Extra response headers, if any.
-    pub headers: Option<HeaderMap>,
-    /// Response body, if any.
-    pub body: Option<String>,
-}
+        let headers = HeaderMap::from_httparse(raw.headers)?;
 
-impl From<StatusCode> for ErrorResponse {
-    fn from(error_code: StatusCode) -> Self {
-        ErrorResponse {
-            error_code,
-            headers: None,
-            body: None,
-        }
+        let mut request = Request::new(());
+        *request.method_mut() = http::Method::GET;
+        *request.headers_mut() = headers;
+        *request.uri_mut() = raw.path.expect("Bug: no path in header").parse()?;
+        // TODO: httparse only supports HTTP 0.9/1.0/1.1 but not HTTP 2.0
+        // so the only valid value we could get in the response would be 1.1.
+        *request.version_mut() = http::Version::HTTP_11;
+
+        Ok(request)
     }
 }
 
@@ -116,14 +91,20 @@ pub trait Callback: Sized {
     /// Called whenever the server read the request from the client and is ready to reply to it.
     /// May return additional reply headers.
     /// Returning an error resulting in rejecting the incoming connection.
-    fn on_request(self, request: &Request) -> StdResult<Option<HeaderMap>, ErrorResponse>;
+    fn on_request(
+        self,
+        request: &Request<()>,
+    ) -> StdResult<Option<HeaderMap>, Response<Option<String>>>;
 }
 
 impl<F> Callback for F
 where
-    F: FnOnce(&Request) -> StdResult<Option<HeaderMap>, ErrorResponse>,
+    F: FnOnce(&Request<()>) -> StdResult<Option<HeaderMap>, Response<Option<String>>>,
 {
-    fn on_request(self, request: &Request) -> StdResult<Option<HeaderMap>, ErrorResponse> {
+    fn on_request(
+        self,
+        request: &Request<()>,
+    ) -> StdResult<Option<HeaderMap>, Response<Option<String>>> {
         self(request)
     }
 }
@@ -133,7 +114,10 @@ where
 pub struct NoCallback;
 
 impl Callback for NoCallback {
-    fn on_request(self, _request: &Request) -> StdResult<Option<HeaderMap>, ErrorResponse> {
+    fn on_request(
+        self,
+        _request: &Request<()>,
+    ) -> StdResult<Option<HeaderMap>, Response<Option<String>>> {
         Ok(None)
     }
 }
@@ -174,7 +158,7 @@ impl<S: Read + Write, C: Callback> ServerHandshake<S, C> {
 }
 
 impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
-    type IncomingData = Request;
+    type IncomingData = Request<()>;
     type InternalStream = S;
     type FinalResult = WebSocket<S>;
 
@@ -200,23 +184,26 @@ impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
 
                 match callback_result {
                     Ok(extra_headers) => {
-                        let response = result.reply(extra_headers)?;
+                        let response = reply(&result, extra_headers)?;
                         ProcessingResult::Continue(HandshakeMachine::start_write(stream, response))
                     }
 
-                    Err(ErrorResponse {
-                        error_code,
-                        headers,
-                        body,
-                    }) => {
-                        self.error_code = Some(error_code.as_u16());
+                    Err(resp) => {
+                        if resp.status().is_success() {
+                            return Err(Error::Protocol(
+                                "Custom response must not be successful".into(),
+                            ));
+                        }
+
+                        self.error_code = Some(resp.status().as_u16());
                         let mut response = format!(
-                            "HTTP/1.1 {} {}\r\n",
-                            error_code.as_str(),
-                            error_code.canonical_reason().unwrap_or("")
+                            "{version:?} {status} {reason}\r\n",
+                            version = resp.version(),
+                            status = resp.status().as_u16(),
+                            reason = resp.status().canonical_reason().unwrap_or("")
                         );
-                        add_headers(&mut response, headers)?;
-                        if let Some(body) = body {
+                        add_headers(&mut response, Some(resp.headers()))?;
+                        if let Some(body) = resp.body() {
                             response += &body;
                         }
                         ProcessingResult::Continue(HandshakeMachine::start_write(stream, response))
@@ -241,6 +228,7 @@ impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
 #[cfg(test)]
 mod tests {
     use super::super::machine::TryParse;
+    use super::reply;
     use super::{HeaderMap, Request};
     use http::header::HeaderName;
     use http::Response;
@@ -249,8 +237,8 @@ mod tests {
     fn request_parsing() {
         const DATA: &'static [u8] = b"GET /script.ws HTTP/1.1\r\nHost: foo.com\r\n\r\n";
         let (_, req) = Request::try_parse(DATA).unwrap().unwrap();
-        assert_eq!(req.path, "/script.ws");
-        assert_eq!(req.headers.get("Host").unwrap(), &b"foo.com"[..]);
+        assert_eq!(req.uri().path(), "/script.ws");
+        assert_eq!(req.headers().get("Host").unwrap(), &b"foo.com"[..]);
     }
 
     #[test]
@@ -264,7 +252,7 @@ mod tests {
             Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
             \r\n";
         let (_, req) = Request::try_parse(DATA).unwrap().unwrap();
-        let _ = req.reply(None).unwrap();
+        let _ = reply(&req, None).unwrap();
 
         let extra_headers = {
             let mut headers = HeaderMap::new();
@@ -279,7 +267,7 @@ mod tests {
 
             headers
         };
-        let reply = req.reply(Some(extra_headers)).unwrap();
+        let reply = reply(&req, Some(extra_headers)).unwrap();
         let (_, req) = Response::try_parse(&reply).unwrap().unwrap();
         assert_eq!(
             req.headers().get("MyCustomHeader").unwrap(),

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn request_parsing() {
-        const DATA: &'static [u8] = b"GET /script.ws HTTP/1.1\r\nHost: foo.com\r\n\r\n";
+        const DATA: &[u8] = b"GET /script.ws HTTP/1.1\r\nHost: foo.com\r\n\r\n";
         let (_, req) = Request::try_parse(DATA).unwrap().unwrap();
         assert_eq!(req.uri().path(), "/script.ws");
         assert_eq!(req.headers().get("Host").unwrap(), &b"foo.com"[..]);
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn request_replying() {
-        const DATA: &'static [u8] = b"\
+        const DATA: &[u8] = b"\
             GET /script.ws HTTP/1.1\r\n\
             Host: foo.com\r\n\
             Connection: upgrade\r\n\

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -227,7 +227,7 @@ impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
             StageResult::DoneWriting(stream) => {
                 if let Some(err) = self.error_code.take() {
                     debug!("Server handshake failed.");
-                    return Err(Error::Http(err));
+                    return Err(Error::Http(StatusCode::from_u16(err)?));
                 } else {
                     debug!("Server handshake done.");
                     let websocket = WebSocket::from_raw_socket(stream, Role::Server, self.config);
@@ -240,10 +240,10 @@ impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::client::Response;
     use super::super::machine::TryParse;
     use super::{HeaderMap, Request};
     use http::header::HeaderName;
+    use http::Response;
 
     #[test]
     fn request_parsing() {
@@ -282,9 +282,9 @@ mod tests {
         let reply = req.reply(Some(extra_headers)).unwrap();
         let (_, req) = Response::try_parse(&reply).unwrap().unwrap();
         assert_eq!(
-            req.headers.get("MyCustomHeader").unwrap(),
+            req.headers().get("MyCustomHeader").unwrap(),
             b"MyCustomValue".as_ref()
         );
-        assert_eq!(req.headers.get("MyVersion").unwrap(), b"LOL".as_ref());
+        assert_eq!(req.headers().get("MyVersion").unwrap(), b"LOL".as_ref());
     }
 }

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -12,7 +12,7 @@ pub use self::frame::{Frame, FrameHeader};
 use crate::error::{Error, Result};
 use input_buffer::{InputBuffer, MIN_READ};
 use log::*;
-use std::io::{Read, Write, Error as IoError, ErrorKind as IoErrorKind};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 
 /// A reader and writer for WebSocket frames.
 #[derive(Debug)]
@@ -199,7 +199,11 @@ impl FrameCodec {
             let len = stream.write(&self.out_buffer)?;
             if len == 0 {
                 // This is the same as "Connection reset by peer"
-                return Err(IoError::new(IoErrorKind::ConnectionReset, "Connection reset while sending").into())
+                return Err(IoError::new(
+                    IoErrorKind::ConnectionReset,
+                    "Connection reset while sending",
+                )
+                .into());
             }
             self.out_buffer.drain(0..len);
         }

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -343,7 +343,7 @@ mod tests {
 
     #[test]
     fn display() {
-        let t = Message::text(format!("test"));
+        let t = Message::text("test".to_owned());
         assert_eq!(t.to_string(), "test".to_owned());
 
         let bin = Message::binary(vec![0, 1, 3, 4, 241]);

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -592,7 +592,7 @@ enum WebSocketState {
 
 impl WebSocketState {
     /// Tell if we're allowed to process normal messages.
-    fn is_active(&self) -> bool {
+    fn is_active(self) -> bool {
         match self {
             WebSocketState::Active => true,
             _ => false,
@@ -602,7 +602,7 @@ impl WebSocketState {
     /// Tell if we should process incoming data. Note that if we send a close frame
     /// but the remote hasn't confirmed, they might have sent data before they receive our
     /// close frame, so we should still pass those to client code, hence ClosedByUs is valid.
-    fn can_read(&self) -> bool {
+    fn can_read(self) -> bool {
         match self {
             WebSocketState::Active | WebSocketState::ClosedByUs => true,
             _ => false,
@@ -610,7 +610,7 @@ impl WebSocketState {
     }
 
     /// Check if the state is active, return error if not.
-    fn check_active(&self) -> Result<()> {
+    fn check_active(self) -> Result<()> {
         match self {
             WebSocketState::Terminated => Err(Error::AlreadyClosed),
             _ => Ok(()),

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -280,7 +280,9 @@ impl WebSocketContext {
 
         // Do not write after sending a close frame.
         if !self.state.is_active() {
-            return Err(Error::Protocol("Sending after closing is not allowed".into()));
+            return Err(Error::Protocol(
+                "Sending after closing is not allowed".into(),
+            ));
         }
 
         if let Some(max_send_queue) = self.config.max_send_queue {
@@ -378,7 +380,9 @@ impl WebSocketContext {
     {
         if let Some(mut frame) = self.frame.read_frame(stream, self.config.max_frame_size)? {
             if !self.state.can_read() {
-                return Err(Error::Protocol("Remote sent frame after having sent a Close Frame".into()));
+                return Err(Error::Protocol(
+                    "Remote sent frame after having sent a Close Frame".into(),
+                ));
             }
             // MUST be 0 unless an extension is negotiated that defines meanings
             // for non-zero values.  If a nonzero value is received and none of
@@ -600,8 +604,7 @@ impl WebSocketState {
     /// close frame, so we should still pass those to client code, hence ClosedByUs is valid.
     fn can_read(&self) -> bool {
         match self {
-            WebSocketState::Active     |
-            WebSocketState::ClosedByUs => true,
+            WebSocketState::Active | WebSocketState::ClosedByUs => true,
             _ => false,
         }
     }

--- a/tests/no_send_after_close.rs
+++ b/tests/no_send_after_close.rs
@@ -39,13 +39,12 @@ fn test_no_send_after_close() {
 
     client_handler.close(None).unwrap(); // send close to client
 
-    let err = client_handler
-        .write_message(Message::Text("Hello WebSocket".into()));
+    let err = client_handler.write_message(Message::Text("Hello WebSocket".into()));
 
-    assert!( err.is_err() );
+    assert!(err.is_err());
 
     match err.unwrap_err() {
-        Error::Protocol(s) => { assert_eq!( "Sending after closing is not allowed", s )}
+        Error::Protocol(s) => assert_eq!("Sending after closing is not allowed", s),
         e => panic!("unexpected error: {:?}", e),
     }
 


### PR DESCRIPTION
Fixes https://github.com/snapview/tungstenite-rs/issues/92

Also contains some minor cleanup in separate commits.