### PR TITLE
Add support for shared websocket messages

### DIFF
--- a/examples/autobahn-server.rs
+++ b/examples/autobahn-server.rs
@@ -32,12 +32,14 @@ fn main() {
 
     for stream in server.incoming() {
         spawn(move || match stream {
-            Ok(stream) => if let Err(err) = handle_client(stream) {
-                match err {
-                    Error::ConnectionClosed | Error::Protocol(_) | Error::Utf8 => (),
-                    e => error!("test: {}", e),
+            Ok(stream) => {
+                if let Err(err) = handle_client(stream) {
+                    match err {
+                        Error::ConnectionClosed | Error::Protocol(_) | Error::Utf8 => (),
+                        e => error!("test: {}", e),
+                    }
                 }
-            },
+            }
             Err(e) => error!("Error accepting stream: {}", e),
         });
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ use std::string;
 use http;
 use httparse;
 
-use crate::protocol::Message;
+use crate::protocol::EitherMessage;
 
 #[cfg(feature = "tls")]
 pub mod tls {
@@ -59,7 +59,7 @@ pub enum Error {
     /// Protocol violation.
     Protocol(Cow<'static, str>),
     /// Message send queue full.
-    SendQueueFull(Message),
+    SendQueueFull(EitherMessage),
     /// UTF coding error
     Utf8,
     /// Invalid URL.

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -105,16 +105,18 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
     let mut req = Vec::new();
     let uri = request.uri();
 
-    let authority = uri.authority()
+    let authority = uri
+        .authority()
         .ok_or_else(|| Error::Url("No host name in the URL".into()))?
         .as_str();
-    let host = if let Some(idx) = authority.find('@') { // handle possible name:password@
+    let host = if let Some(idx) = authority.find('@') {
+        // handle possible name:password@
         authority.split_at(idx + 1).1
     } else {
         authority
     };
     if authority.is_empty() {
-        return Err(Error::Url("URL contains empty host name".into()))
+        return Err(Error::Url("URL contains empty host name".into()));
     }
 
     write!(
@@ -261,8 +263,8 @@ fn generate_key() -> String {
 #[cfg(test)]
 mod tests {
     use super::super::machine::TryParse;
-    use crate::client::IntoClientRequest;
     use super::{generate_key, generate_request, Response};
+    use crate::client::IntoClientRequest;
 
     #[test]
     fn random_keys() {
@@ -299,7 +301,9 @@ mod tests {
 
     #[test]
     fn request_formatting_with_host() {
-        let request = "wss://localhost:9001/getCaseCount".into_client_request().unwrap();
+        let request = "wss://localhost:9001/getCaseCount"
+            .into_client_request()
+            .unwrap();
         let key = "A70tsIbeMZUbJHh5BWFw6Q==";
         let correct = b"\
             GET /getCaseCount HTTP/1.1\r\n\
@@ -316,7 +320,9 @@ mod tests {
 
     #[test]
     fn request_formatting_with_at() {
-        let request = "wss://user:pass@localhost:9001/getCaseCount".into_client_request().unwrap();
+        let request = "wss://user:pass@localhost:9001/getCaseCount"
+            .into_client_request()
+            .unwrap();
         let key = "A70tsIbeMZUbJHh5BWFw6Q==";
         let correct = b"\
             GET /getCaseCount HTTP/1.1\r\n\

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -172,7 +172,7 @@ impl FrameCodec {
 
         let (header, length) = self.header.take().expect("Bug: no frame header");
         debug_assert_eq!(payload.len() as u64, length);
-        let frame = Frame::from_payload(header, payload);
+        let frame = Frame::from_payload(header, payload.into());
         trace!("received frame {}", frame);
         Ok(Some(frame))
     }
@@ -228,11 +228,11 @@ mod tests {
         let mut sock = FrameSocket::new(raw);
 
         assert_eq!(
-            sock.read_frame(None).unwrap().unwrap().into_data(),
+            sock.read_frame(None).unwrap().unwrap().into_payload().unwrap_bytes(),
             vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
         );
         assert_eq!(
-            sock.read_frame(None).unwrap().unwrap().into_data(),
+            sock.read_frame(None).unwrap().unwrap().into_payload().unwrap_bytes(),
             vec![0x03, 0x02, 0x01]
         );
         assert!(sock.read_frame(None).unwrap().is_none());
@@ -246,7 +246,7 @@ mod tests {
         let raw = Cursor::new(vec![0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
         let mut sock = FrameSocket::from_partially_read(raw, vec![0x82, 0x07, 0x01]);
         assert_eq!(
-            sock.read_frame(None).unwrap().unwrap().into_data(),
+            sock.read_frame(None).unwrap().unwrap().into_payload().unwrap_bytes(),
             vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
         );
     }

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -6,6 +6,8 @@ use std::str;
 use super::frame::CloseFrame;
 use crate::error::{Error, Result};
 
+use bytes::Bytes;
+
 mod string_collect {
 
     use utf8;
@@ -166,6 +168,35 @@ impl IncompleteMessage {
 pub enum IncompleteMessageType {
     Text,
     Binary,
+}
+
+/// Either a owned or shard `WebSocket` message.
+#[derive(Debug, Clone)]
+pub enum EitherMessage {
+    /// A owned `WebSocket` message.
+    Message(Message),
+
+    /// A shared `WebSocket` message.
+    SharedMessage(SharedMessage),
+}
+
+impl From<Message> for EitherMessage {
+    fn from(m: Message) -> Self {
+        EitherMessage::Message(m)
+    }
+}
+
+impl From<SharedMessage> for EitherMessage {
+    fn from(m: SharedMessage) -> Self {
+        EitherMessage::SharedMessage(m)
+    }
+}
+
+/// A shared websocket message.
+#[derive(Debug, Clone)]
+pub enum SharedMessage {
+    /// A shared binary `WebSocket` message.
+    Binary(Bytes),
 }
 
 /// An enum representing the various forms of a WebSocket message.

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -1,15 +1,15 @@
 //! Verifies that the server returns a `ConnectionClosed` error when the connection
 //! is closedd from the server's point of view and drop the underlying tcp socket.
 
-use std::net::{TcpStream, TcpListener};
+use std::net::{TcpListener, TcpStream};
 use std::process::exit;
 use std::thread::{sleep, spawn};
 use std::time::Duration;
 
-use tungstenite::{accept, connect, Error, Message, WebSocket, stream::Stream};
 use native_tls::TlsStream;
-use url::Url;
 use net2::TcpStreamExt;
+use tungstenite::{accept, connect, stream::Stream, Error, Message, WebSocket};
+use url::Url;
 
 type Sock = WebSocket<Stream<TcpStream, TlsStream<TcpStream>>>;
 
@@ -26,8 +26,8 @@ where
         exit(1);
     });
 
-    let server = TcpListener::bind(("127.0.0.1", port))
-        .expect("Can't listen, is port already in use?");
+    let server =
+        TcpListener::bind(("127.0.0.1", port)).expect("Can't listen, is port already in use?");
 
     let client_thread = spawn(move || {
         let (client, _) = connect(Url::parse(&format!("ws://localhost:{}/socket", port)).unwrap())
@@ -46,7 +46,8 @@ where
 
 #[test]
 fn test_server_close() {
-    do_test(3012,
+    do_test(
+        3012,
         |mut cli_sock| {
             cli_sock
                 .write_message(Message::Text("Hello WebSocket".into()))
@@ -75,12 +76,14 @@ fn test_server_close() {
                 Error::ConnectionClosed => {}
                 _ => panic!("unexpected error: {:?}", err),
             }
-        });
+        },
+    );
 }
 
 #[test]
 fn test_evil_server_close() {
-    do_test(3013,
+    do_test(
+        3013,
         |mut cli_sock| {
             cli_sock
                 .write_message(Message::Text("Hello WebSocket".into()))
@@ -106,14 +109,19 @@ fn test_evil_server_close() {
             let message = srv_sock.read_message().unwrap(); // receive acknowledgement
             assert!(message.is_close());
             // and now just drop the connection without waiting for `ConnectionClosed`
-            srv_sock.get_mut().set_linger(Some(Duration::from_secs(0))).unwrap();
+            srv_sock
+                .get_mut()
+                .set_linger(Some(Duration::from_secs(0)))
+                .unwrap();
             drop(srv_sock);
-        });
+        },
+    );
 }
 
 #[test]
 fn test_client_close() {
-    do_test(3014,
+    do_test(
+        3014,
         |mut cli_sock| {
             cli_sock
                 .write_message(Message::Text("Hello WebSocket".into()))
@@ -137,7 +145,9 @@ fn test_client_close() {
             let message = srv_sock.read_message().unwrap();
             assert_eq!(message.into_data(), b"Hello WebSocket");
 
-            srv_sock.write_message(Message::Text("From Server".into())).unwrap();
+            srv_sock
+                .write_message(Message::Text("From Server".into()))
+                .unwrap();
 
             let message = srv_sock.read_message().unwrap(); // receive close from client
             assert!(message.is_close());
@@ -147,6 +157,6 @@ fn test_client_close() {
                 Error::ConnectionClosed => {}
                 _ => panic!("unexpected error: {:?}", err),
             }
-        });
-
+        },
+    );
 }


### PR DESCRIPTION
This adds the `SharedMessage` enum as well as the `write_shared_message`
for both `Websocket` and the `WebsocketContext`.

This fixes #96.

Essentially I tried to minimize the breaking changes of this PR since its kind of a edge case. However the `Payload` enum might had some additional overhead (although probably minimal) by adding  branches.

Currently the only breaking change is in the `Error::SendQueueFull(EitherMessage)` instead of `Error::SendQueueFull(Message)`. We could however add an error variant to circumvent that (i.e Error::SharedSendQueueFull).