### PR TITLE
Make mask public on FrameHeader

### DIFF
--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -51,7 +51,7 @@ pub struct FrameHeader {
     /// WebSocket protocol opcode.
     pub opcode: OpCode,
     /// A frame mask, if any.
-    mask: Option<[u8; 4]>,
+    pub mask: Option<[u8; 4]>,
 }
 
 impl Default for FrameHeader {


### PR DESCRIPTION
Without the ability to get the mask, having the `FrameHeader` struct as a public type along with functions like `parse` is somewhat useless. I can't see any reason why it shouldn't be public.