### PR TITLE
Fix ws request subportocol lowercase header

### DIFF
--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -138,7 +138,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
 
     for (k, v) in request.headers() {
         let mut k = k.as_str();
-        if  k == "sec-websocket-protocol".to_string(){
+        if  k == "sec-websocket-protocol" {
             k = "Sec-WebSocket-Protocol";
         }
         writeln!(req, "{}: {}\r", k, v.to_str()?).unwrap();

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -135,7 +135,12 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
         key = key
     )
     .unwrap();
+
     for (k, v) in request.headers() {
+        let mut k = k.as_str();
+        if  k == "sec-websocket-protocol".to_string(){
+            k = "Sec-WebSocket-Protocol";
+        }
         writeln!(req, "{}: {}\r", k, v.to_str()?).unwrap();
     }
     writeln!(req, "\r").unwrap();


### PR DESCRIPTION
[RFC6445 Sec11.3](https://tools.ietf.org/html/rfc6455#section-11.3) specifies several headers like `Sec-WebSocket-Protocol`. While it does not specifies the key should be case insensitive, many server only accepts case sensitive requests. However [http](https://docs.rs/http/0.2.1/http/) case every key to lowercase for convince. [hyper](https://docs.rs/hyper/0.13.5/hyper/) has an issue to solve this problem (https://github.com/hyperium/hyper/issues/1492), but not in http. This is a workaround to make the websocket server happy. 