### PR TITLE
Deduplicate the reason line in HTTP responses

### DIFF
--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -89,10 +89,9 @@ pub fn create_response(request: &Request) -> Result<Response> {
 fn write_response<T>(w: &mut dyn io::Write, response: &HttpResponse<T>) -> Result<()> {
     writeln!(
         w,
-        "{version:?} {status} {reason}\r",
+        "{version:?} {status}\r",
         version = response.version(),
-        status = response.status(),
-        reason = response.status().canonical_reason().unwrap_or(""),
+        status = response.status()
     )?;
 
     for (k, v) in response.headers() {


### PR DESCRIPTION
The impl of Display for StatusCode already includes the canonical reason
if it exists. The current implementation duplicates this (e.g. the
status line will read "101 Switching Protocols Switching Protocols", or
"400 Bad Request Bad Request".