### PR TITLE
GH-46 Return the response in case of non-101 response from server

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,8 @@ pub enum Error {
     Url(Cow<'static, str>),
     /// HTTP error.
     Http(http::StatusCode),
+    /// HTTP response error.
+    HttpResponse(http::Response<()>),
     /// HTTP format error.
     HttpFormat(http::Error),
 }
@@ -83,6 +85,7 @@ impl fmt::Display for Error {
             Error::Utf8 => write!(f, "UTF-8 encoding error"),
             Error::Url(ref msg) => write!(f, "URL error: {}", msg),
             Error::Http(code) => write!(f, "HTTP error: {}", code),
+            Error::HttpResponse(ref res) => write!(f, "HTTP response error: {}", res.status()),
             Error::HttpFormat(ref err) => write!(f, "HTTP format error: {}", err),
         }
     }


### PR DESCRIPTION
Following redirects inside the lib (https://github.com/snapview/tungstenite-rs/pull/148)
has few flows: there is no redirect loop prevention in this case, in case of using the lib in proxy it's impossible to return the upstream response to browser, etc.

With this change response is propagated to the lib's user, so it can decide what to do with it
in case of redirects: either send it to browser for it to follow redirects or implement redirect following on their side.