### PR TITLE
Add a custom response builder

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -119,10 +119,8 @@ pub fn connect_with_config<Req: IntoClientRequest>(
     }
 
     fn create_request(parts: &Parts, uri: &Uri) -> Request {
-        let mut builder = Request::builder()
-            .uri(uri.clone())
-            .method(parts.method.clone())
-            .version(parts.version);
+        let mut builder =
+            Request::builder().uri(uri.clone()).method(parts.method.clone()).version(parts.version);
         *builder.headers_mut().expect("Failed to create `Request`") = parts.headers.clone();
         builder.body(()).expect("Failed to create `Request`")
     }

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -81,18 +81,12 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
 
 /// Create a response for the request.
 pub fn create_response(request: &Request) -> Result<Response> {
-    match create_parts(&request) {
-        Ok(builder) => Ok(builder.body(())?),
-        Err(e) => Err(e)
-    }
+    Ok(create_parts(&request)?.body(())?)
 }
 
 /// Create a response for the request, with a custom body builder
-pub fn create_response_t<T>(request: &HttpRequest<T>, empty: impl FnOnce() -> T) -> Result<HttpResponse<T>> {
-    match create_parts(&request) {
-        Ok(builder) => Ok(builder.body(empty())?),
-        Err(e) => Err(e)
-    }
+pub fn create_custom_response<T>(request: &HttpRequest<T>, generate_body: impl FnOnce() -> T) -> Result<HttpResponse<T>> {
+    Ok(create_parts(&request)?.body(generate_body())?)
 }
 
 // Assumes that this is a valid response

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -6,8 +6,9 @@ use std::{
     result::Result as StdResult,
 };
 
-use http::{HeaderMap, Request as HttpRequest, Response as HttpResponse, StatusCode};
-use http::response::Builder;
+use http::{
+    response::Builder, HeaderMap, Request as HttpRequest, Response as HttpResponse, StatusCode,
+};
 use httparse::Status;
 use log::*;
 
@@ -75,7 +76,7 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
         .header("Connection", "Upgrade")
         .header("Upgrade", "websocket")
         .header("Sec-WebSocket-Accept", convert_key(key.as_bytes())?);
-    
+
     Ok(builder)
 }
 
@@ -84,8 +85,11 @@ pub fn create_response(request: &Request) -> Result<Response> {
     Ok(create_parts(&request)?.body(())?)
 }
 
-/// Create a response for the request, with a custom body builder
-pub fn create_custom_response<T>(request: &HttpRequest<T>, generate_body: impl FnOnce() -> T) -> Result<HttpResponse<T>> {
+/// Create a response for the request with a custom body.
+pub fn create_response_with_body<T>(
+    request: &HttpRequest<T>,
+    generate_body: impl FnOnce() -> T,
+) -> Result<HttpResponse<T>> {
     Ok(create_parts(&request)?.body(generate_body())?)
 }
 


### PR DESCRIPTION
I'd like to build my reponse so I can feed it into my own http pipeline, that's impossible without having the ability of getting a `Reponse<T>`