### PR TITLE
WebSocketConfig extended to allow accepting unmasked client frames

### DIFF
--- a/examples/srv_accept_unmasked_frames.rs
+++ b/examples/srv_accept_unmasked_frames.rs
@@ -34,7 +34,7 @@ fn main() {
                 // This is not in compliance with RFC 6455 but might be handy in some
                 // rare cases where it is necessary to integrate with existing/legacy
                 // clients which are sending unmasked frames
-                server_allow_unmasked: true,
+                accept_unmasked_frames: true,
             });
 
             let mut websocket = accept_hdr_with_config(stream.unwrap(), callback, config).unwrap();

--- a/examples/srv_accept_unmasked_frames.rs
+++ b/examples/srv_accept_unmasked_frames.rs
@@ -34,7 +34,7 @@ fn main() {
                 // This is not in compliance with RFC 6455 but might be handy in some
                 // rare cases where it is necessary to integrate with existing/legacy
                 // clients which are sending unmasked frames
-                server_allow_unmasked: Some(true),
+                server_allow_unmasked: true,
             });
 
             let mut websocket = accept_hdr_with_config(stream.unwrap(), callback, config).unwrap();

--- a/examples/srv_accept_unmasked_frames.rs
+++ b/examples/srv_accept_unmasked_frames.rs
@@ -1,0 +1,50 @@
+use std::{net::TcpListener, thread::spawn};
+use tungstenite::{
+    handshake::server::{Request, Response},
+    protocol::WebSocketConfig,
+    server::accept_hdr_with_config,
+};
+
+fn main() {
+    env_logger::init();
+    let server = TcpListener::bind("127.0.0.1:3012").unwrap();
+    for stream in server.incoming() {
+        spawn(move || {
+            let callback = |req: &Request, mut response: Response| {
+                println!("Received a new ws handshake");
+                println!("The request's path is: {}", req.uri().path());
+                println!("The request's headers are:");
+                for (ref header, _value) in req.headers() {
+                    println!("* {}", header);
+                }
+
+                // Let's add an additional header to our response to the client.
+                let headers = response.headers_mut();
+                headers.append("MyCustomHeader", ":)".parse().unwrap());
+                headers.append("SOME_TUNGSTENITE_HEADER", "header_value".parse().unwrap());
+
+                Ok(response)
+            };
+
+            let config = Some(WebSocketConfig {
+                max_send_queue: None,
+                max_message_size: None,
+                max_frame_size: None,
+                // This setting allows to accept client frames which are not masked
+                // This is not in compliance with RFC 6455 but might be handy in some
+                // rare cases where it is necessary to integrate with existing/legacy
+                // clients which are sending unmasked frames
+                server_allow_unmasked: Some(true),
+            });
+
+            let mut websocket = accept_hdr_with_config(stream.unwrap(), callback, config).unwrap();
+
+            loop {
+                let msg = websocket.read_message().unwrap();
+                if msg.is_binary() || msg.is_text() {
+                    println!("received message {}", msg);
+                }
+            }
+        });
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -457,8 +457,7 @@ impl WebSocketContext {
                         // The server MUST close the connection upon receiving a
                         // frame that is not masked. (RFC 6455)
                         // The only exception here is if the user explicitly accepts given
-                        // stream (by tungstenite::server::accept_with_config or tungstenite::server::accept_hdr_with_config)
-                        // with WebSocketConfig.accept_unmasked_frames set to true
+                        // stream by setting WebSocketConfig.accept_unmasked_frames to true
                         if !self.config.accept_unmasked_frames {
                             return Err(Error::Protocol(
                                 "Received an unmasked frame from client".into(),

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -54,7 +54,7 @@ pub struct WebSocketConfig {
     /// Even though this behaviour is not in compliance with RFC 6455 (which requires the server
     /// to close the connection when unmasked frame from client is received) it might be handy in some cases
     /// as there are existing applications sending unmasked client frames.
-    pub server_allow_unmasked: Option<bool>,
+    pub server_allow_unmasked: bool,
 }
 
 impl Default for WebSocketConfig {
@@ -63,7 +63,7 @@ impl Default for WebSocketConfig {
             max_send_queue: None,
             max_message_size: Some(64 << 20),
             max_frame_size: Some(16 << 20),
-            server_allow_unmasked: None,
+            server_allow_unmasked: false,
         }
     }
 }
@@ -457,16 +457,8 @@ impl WebSocketContext {
                         // frame that is not masked. (RFC 6455)
                         // The only exception here is if the user explicitly accepts given
                         // stream (by tungstenite::server::accept_with_config or tungstenite::server::accept_hdr_with_config)
-                        // with WebSocketConfig.server_allow_unmasked set to Some(true)
-                        if let Some(server_allow_unmasked_val) =
-                            self.get_config().server_allow_unmasked
-                        {
-                            if server_allow_unmasked_val == false {
-                                return Err(Error::Protocol(
-                                    "Received an unmasked frame from client".into(),
-                                ));
-                            }
-                        } else {
+                        // with WebSocketConfig.server_allow_unmasked set to true
+                        if self.get_config().server_allow_unmasked == false {
                             return Err(Error::Protocol(
                                 "Received an unmasked frame from client".into(),
                             ));

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -453,16 +453,14 @@ impl WebSocketContext {
                         // A server MUST remove masking for data frames received from a client
                         // as described in Section 5.3. (RFC 6455)
                         frame.apply_mask()
-                    } else {
+                    } else if !self.config.accept_unmasked_frames {
                         // The server MUST close the connection upon receiving a
                         // frame that is not masked. (RFC 6455)
                         // The only exception here is if the user explicitly accepts given
                         // stream by setting WebSocketConfig.accept_unmasked_frames to true
-                        if !self.config.accept_unmasked_frames {
-                            return Err(Error::Protocol(
-                                "Received an unmasked frame from client".into(),
-                            ));
-                        }
+                        return Err(Error::Protocol(
+                            "Received an unmasked frame from client".into(),
+                        ));
                     }
                 }
                 Role::Client => {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -53,7 +53,9 @@ pub struct WebSocketConfig {
     /// If set to true it will allow the websocket server to accept unmasked frames from client.
     /// Even though this behaviour is not in compliance with RFC 6455 (which requires the server
     /// to close the connection when unmasked frame from client is received) it might be handy in some cases
-    /// as there are existing applications sending unmasked client frames.
+    /// as there are existing applications sending unmasked client frames. By default (i.e. unless not explicitly specified)
+    /// this flag is set to false which means violation of RFC 6455 is not allowed and unmasked client frames will be rejected
+    ///by websocket server.
     pub server_allow_unmasked: bool,
 }
 


### PR DESCRIPTION
This change will make possible for websocket server to accept unmasked frames. This is needed since some legacy commercially used solutions are unfortunately violating  RFC 6455 and sending (acting as websocket clients)  unmasked client frames. Example is **_Asterisk AudioFork_** (https://github.com/nadirhamid/asterisk-audiofork) used in asterisk based telephony solutions. 

Also other widely used websocket implementations (e.g. **_Node.JS WS_** library - https://www.npmjs.com/package/ws) allow to create WS servers accepting unmasked client frames.