### PR TITLE
Update to bytes 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1.3.2"
 bytes = "1.0"
 http = "0.2"
 httparse = "1.3.4"
-input_buffer = { version = "0.3.0", git = "https://github.com/nickelc/input_buffer.git", branch = "bytes" }
+input_buffer = { version = "0.4.0", git = "https://github.com/snapview/input_buffer.git" }
 log = "0.4.8"
 rand = "0.7.2"
 sha-1 = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ tls-vendored = ["native-tls", "native-tls/vendored"]
 [dependencies]
 base64 = "0.13.0"
 byteorder = "1.3.2"
-bytes = "0.5"
+bytes = "1.0"
 http = "0.2"
 httparse = "1.3.4"
-input_buffer = "0.3.0"
+input_buffer = { version = "0.3.0", git = "https://github.com/nickelc/input_buffer.git", branch = "bytes" }
 log = "0.4.8"
 rand = "0.7.2"
 sha-1 = "0.9"

--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -51,7 +51,7 @@ impl<Stream: Read + Write> HandshakeMachine<Stream> {
                     .no_block()?;
                 match read {
                     Some(0) => Err(Error::Protocol("Handshake not finished".into())),
-                    Some(_) => Ok(if let Some((size, obj)) = Obj::try_parse(Buf::bytes(&buf))? {
+                    Some(_) => Ok(if let Some((size, obj)) = Obj::try_parse(Buf::chunk(&buf))? {
                         buf.advance(size);
                         RoundResult::StageFinished(StageResult::DoneReading {
                             result: obj,
@@ -72,7 +72,7 @@ impl<Stream: Read + Write> HandshakeMachine<Stream> {
             }
             HandshakeState::Writing(mut buf) => {
                 assert!(buf.has_remaining());
-                if let Some(size) = self.stream.write(Buf::bytes(&buf)).no_block()? {
+                if let Some(size) = self.stream.write(Buf::chunk(&buf)).no_block()? {
                     assert!(size > 0);
                     buf.advance(size);
                     Ok(if buf.has_remaining() {


### PR DESCRIPTION
blocked by: snapview/input_buffer#4 and release of input_buffer v0.4
closes: #162 