### PR TITLE
Add support for rustls as TLS backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Add `CapacityError`, `UrlError`, and `ProtocolError` types to represent the different types of capacity, URL, and protocol errors respectively.
 - Modify variants `Error::Capacity`, `Error::Url`, and `Error::Protocol` to hold the above errors types instead of string error messages.
+- Add support for `rustls` as TLS backend. The previous `tls` feature flag is now removed in favor
+  of `native-tls` and `rustls-tls`, which allows to pick the TLS backend. The error API surface had
+  to be changed to support the new error types coming from rustls related crates.
 
 # 0.12.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ all-features = true
 
 [features]
 default = []
-use-native-tls = ["native-tls"]
-use-native-tls-vendored = ["use-native-tls", "native-tls/vendored"]
-use-rustls = ["rustls", "webpki", "webpki-roots"]
+native-tls = ["native-tls-crate"]
+native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
+rustls-tls = ["rustls", "webpki", "webpki-roots"]
 
 [dependencies]
 base64 = "0.13.0"
@@ -35,8 +35,9 @@ thiserror = "1.0.23"
 url = "2.1.0"
 utf-8 = "0.7.5"
 
-[dependencies.native-tls]
+[dependencies.native-tls-crate]
 optional = true
+package = "native-tls"
 version = "0.2.3"
 
 [dependencies.rustls]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ features = ["native-tls"]
 
 [features]
 default = []
-native-tls-vendored = ["native-tls", "native-tls/vendored"]
-rustls-tls = ["rustls", "webpki", "webpki-roots"]
+use-native-tls = ["native-tls"]
+use-native-tls-vendored = ["use-native-tls", "native-tls/vendored"]
+use-rustls = ["rustls", "webpki", "webpki-roots"]
 
 [dependencies]
 base64 = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 all-features = true
 
 [features]
-default = []
+default = ["native-tls"]
 native-tls = ["native-tls-crate"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
 rustls-tls = ["rustls", "webpki", "webpki-roots"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.13.0"
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["native-tls"]
+all-features = true
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,13 @@ repository = "https://github.com/snapview/tungstenite-rs"
 version = "0.11.1"
 edition = "2018"
 
+[package.metadata.docs.rs]
+features = ["native-tls"]
+
 [features]
-default = ["tls"]
-tls = ["native-tls"]
-tls-vendored = ["native-tls", "native-tls/vendored"]
+default = []
+native-tls-vendored = ["native-tls", "native-tls/vendored"]
+rustls-tls = ["rustls", "webpki", "webpki-roots"]
 
 [dependencies]
 base64 = "0.13.0"
@@ -33,6 +36,18 @@ utf-8 = "0.7.5"
 [dependencies.native-tls]
 optional = true
 version = "0.2.3"
+
+[dependencies.rustls]
+optional = true
+version = "0.19.0"
+
+[dependencies.webpki]
+optional = true
+version = "0.21.4"
+
+[dependencies.webpki-roots]
+optional = true
+version = "0.21.0"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Features
 --------
 
 Tungstenite provides a complete implementation of the WebSocket specification.
-TLS is supported on all platforms using native-tls or rustls available through the `use-native-tls`
-and `use-rustls` feature flags.
+TLS is supported on all platforms using native-tls or rustls available through the `native-tls`
+and `rustls-tls` feature flags.
 
 There is no support for permessage-deflate at the moment. It's planned.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Features
 --------
 
 Tungstenite provides a complete implementation of the WebSocket specification.
-TLS is supported on all platforms using native-tls.
+TLS is supported on all platforms using native-tls or rustls available through the `use-native-tls`
+and `use-rustls` feature flags.
 
 There is no support for permessage-deflate at the moment. It's planned.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -129,8 +129,8 @@ use crate::{
 /// custom stream, call `client` instead.
 ///
 /// This function uses `native_tls` or `rustls` to do TLS depending on the feature flags enabled. If
-/// you want to use other TLS libraries, use `client` instead. There is no need to enable the "tls"
-/// feature if you don't call `connect` since it's the only function that uses native_tls or rustls.
+/// you want to use other TLS libraries, use `client` instead. There is no need to enable any of
+/// the `*-tls` features if you don't call `connect` since it's the only function that uses them.
 pub fn connect_with_config<Req: IntoClientRequest>(
     request: Req,
     config: Option<WebSocketConfig>,
@@ -197,8 +197,8 @@ pub fn connect_with_config<Req: IntoClientRequest>(
 /// custom stream, call `client` instead.
 ///
 /// This function uses `native_tls` or `rustls` to do TLS depending on the feature flags enabled. If
-/// you want to use other TLS libraries, use `client` instead. There is no need to enable the "tls"
-/// feature if you don't call `connect` since it's the only function that uses native_tls or rustls.
+/// you want to use other TLS libraries, use `client` instead. There is no need to enable any of
+/// the `*-tls` features if you don't call `connect` since it's the only function that uses them.
 pub fn connect<Req: IntoClientRequest>(request: Req) -> Result<(WebSocket<AutoStream>, Response)> {
     connect_with_config(request, None, 3)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,10 +16,10 @@ use crate::{
     protocol::WebSocketConfig,
 };
 
-#[cfg(feature = "use-native-tls")]
+#[cfg(feature = "native-tls")]
 mod encryption {
-    pub use native_tls::TlsStream;
-    use native_tls::{HandshakeError as TlsHandshakeError, TlsConnector};
+    pub use native_tls_crate::TlsStream;
+    use native_tls_crate::{HandshakeError as TlsHandshakeError, TlsConnector};
     use std::net::TcpStream;
 
     pub use crate::stream::Stream as StreamSwitcher;
@@ -47,7 +47,7 @@ mod encryption {
     }
 }
 
-#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
+#[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
 mod encryption {
     use rustls::ClientConfig;
     pub use rustls::{ClientSession, StreamOwned};
@@ -80,7 +80,7 @@ mod encryption {
     }
 }
 
-#[cfg(not(any(feature = "use-native-tls", feature = "use-rustls")))]
+#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
 mod encryption {
     use std::net::TcpStream;
 
@@ -116,7 +116,7 @@ use crate::{
 /// equal to calling `connect()` function.
 ///
 /// The URL may be either ws:// or wss://.
-/// To support wss:// URLs, feature `use-native-tls` or `use-rustls` must be turned on.
+/// To support wss:// URLs, feature `native-tls` or `rustls-tls` must be turned on.
 ///
 /// This function "just works" for those who wants a simple blocking solution
 /// similar to `std::net::TcpStream`. If you want a non-blocking or other
@@ -184,7 +184,7 @@ pub fn connect_with_config<Req: IntoClientRequest>(
 /// Connect to the given WebSocket in blocking mode.
 ///
 /// The URL may be either ws:// or wss://.
-/// To support wss:// URLs, feature `use-native-tls` or `use-rustls` must be turned on.
+/// To support wss:// URLs, feature `native-tls` or `rustls-tls` must be turned on.
 ///
 /// This function "just works" for those who wants a simple blocking solution
 /// similar to `std::net::TcpStream`. If you want a non-blocking or other

--- a/src/client.rs
+++ b/src/client.rs
@@ -47,7 +47,7 @@ mod encryption {
     }
 }
 
-#[cfg(feature = "use-rustls")]
+#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
 mod encryption {
     use rustls::ClientConfig;
     pub use rustls::{ClientSession, StreamOwned};

--- a/src/client.rs
+++ b/src/client.rs
@@ -89,7 +89,7 @@ mod encryption {
         stream::Mode,
     };
 
-    /// TLS support is nod compiled in, this is just standard `TcpStream`.
+    /// TLS support is not compiled in, this is just standard `TcpStream`.
     pub type AutoStream = TcpStream;
 
     pub fn wrap_stream(stream: TcpStream, _domain: &str, mode: Mode) -> Result<AutoStream> {
@@ -116,15 +116,15 @@ use crate::{
 /// equal to calling `connect()` function.
 ///
 /// The URL may be either ws:// or wss://.
-/// To support wss:// URLs, feature "tls" must be turned on.
+/// To support wss:// URLs, feature `use-native-tls` or `use-rustls` must be turned on.
 ///
 /// This function "just works" for those who wants a simple blocking solution
 /// similar to `std::net::TcpStream`. If you want a non-blocking or other
 /// custom stream, call `client` instead.
 ///
-/// This function uses `native_tls` to do TLS. If you want to use other TLS libraries,
-/// use `client` instead. There is no need to enable the "tls" feature if you don't call
-/// `connect` since it's the only function that uses native_tls.
+/// This function uses `native_tls` or `rustls` to do TLS depending on the feature flags enabled. If
+/// you want to use other TLS libraries, use `client` instead. There is no need to enable the "tls"
+/// feature if you don't call `connect` since it's the only function that uses native_tls or rustls.
 pub fn connect_with_config<Req: IntoClientRequest>(
     request: Req,
     config: Option<WebSocketConfig>,
@@ -184,15 +184,15 @@ pub fn connect_with_config<Req: IntoClientRequest>(
 /// Connect to the given WebSocket in blocking mode.
 ///
 /// The URL may be either ws:// or wss://.
-/// To support wss:// URLs, feature "tls" must be turned on.
+/// To support wss:// URLs, feature `use-native-tls` or `use-rustls` must be turned on.
 ///
 /// This function "just works" for those who wants a simple blocking solution
 /// similar to `std::net::TcpStream`. If you want a non-blocking or other
 /// custom stream, call `client` instead.
 ///
-/// This function uses `native_tls` to do TLS. If you want to use other TLS libraries,
-/// use `client` instead. There is no need to enable the "tls" feature if you don't call
-/// `connect` since it's the only function that uses native_tls.
+/// This function uses `native_tls` or `rustls` to do TLS depending on the feature flags enabled. If
+/// you want to use other TLS libraries, use `client` instead. There is no need to enable the "tls"
+/// feature if you don't call `connect` since it's the only function that uses native_tls or rustls.
 pub fn connect<Req: IntoClientRequest>(request: Req) -> Result<(WebSocket<AutoStream>, Response)> {
     connect_with_config(request, None, 3)
 }
@@ -213,7 +213,7 @@ fn connect_to_some(addrs: &[SocketAddr], uri: &Uri, mode: Mode) -> Result<AutoSt
 /// Get the mode of the given URL.
 ///
 /// This function may be used to ease the creation of custom TLS streams
-/// in non-blocking algorithmss or for use with TLS libraries other than `native_tls`.
+/// in non-blocking algorithms or for use with TLS libraries other than `native_tls` or `rustls`.
 pub fn uri_mode(uri: &Uri) -> Result<Mode> {
     match uri.scheme_str() {
         Some("ws") => Ok(Mode::Plain),

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,7 @@ use crate::{
     protocol::WebSocketConfig,
 };
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "use-native-tls")]
 mod encryption {
     pub use native_tls::TlsStream;
     use native_tls::{HandshakeError as TlsHandshakeError, TlsConnector};
@@ -47,7 +47,7 @@ mod encryption {
     }
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "use-rustls")]
 mod encryption {
     use rustls::ClientConfig;
     pub use rustls::{ClientSession, StreamOwned};
@@ -80,7 +80,7 @@ mod encryption {
     }
 }
 
-#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+#[cfg(not(any(feature = "use-native-tls", feature = "use-rustls")))]
 mod encryption {
     use std::net::TcpStream;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,13 +5,13 @@ use std::{borrow::Cow, error::Error as ErrorTrait, fmt, io, result, str, string}
 use crate::protocol::Message;
 use http::Response;
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "use-native-tls")]
 pub mod tls {
     //! TLS error wrapper module, feature-gated.
     pub use native_tls::Error;
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "use-rustls")]
 pub mod tls {
     //! TLS error wrapper module, feature-gated.
     pub use rustls::TLSError as Error;
@@ -47,13 +47,13 @@ pub enum Error {
     /// Input-output error. Apart from WouldBlock, these are generally errors with the
     /// underlying connection and you should probably consider them fatal.
     Io(io::Error),
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "use-native-tls")]
     /// TLS error
     Tls(tls::Error),
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(feature = "use-rustls")]
     /// TLS error
     Tls(tls::Error),
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(feature = "use-rustls")]
     /// DNS name resolution error.
     Dns(tls::DnsError),
     /// - When reading: buffer capacity exhausted.
@@ -80,11 +80,11 @@ impl fmt::Display for Error {
             Error::ConnectionClosed => write!(f, "Connection closed normally"),
             Error::AlreadyClosed => write!(f, "Trying to work with closed connection"),
             Error::Io(ref err) => write!(f, "IO error: {}", err),
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "use-native-tls")]
             Error::Tls(ref err) => write!(f, "TLS error: {}", err),
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "use-rustls")]
             Error::Tls(ref err) => write!(f, "TLS error: {}", err),
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "use-rustls")]
             Error::Dns(ref err) => write!(f, "Invalid DNS name: {}", err),
             Error::Capacity(ref msg) => write!(f, "Space limit exceeded: {}", msg),
             Error::Protocol(ref msg) => write!(f, "WebSocket protocol error: {}", msg),
@@ -153,21 +153,21 @@ impl From<http::Error> for Error {
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "use-native-tls")]
 impl From<tls::Error> for Error {
     fn from(err: tls::Error) -> Self {
         Error::Tls(err)
     }
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "use-rustls")]
 impl From<tls::Error> for Error {
     fn from(err: tls::Error) -> Self {
         Error::Tls(err)
     }
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "use-rustls")]
 impl From<tls::DnsError> for Error {
     fn from(err: tls::DnsError) -> Self {
         Error::Dns(err)

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
     /// Note that this error variant is enabled unconditionally even if no TLS feature is enabled,
     /// to provide a feature-agnostic API surface.
     #[error("TLS error: {0}")]
-    TlsNative(#[from] TlsError),
+    Tls(#[from] TlsError),
     /// - When reading: buffer capacity exhausted.
     /// - When writing: your message is bigger than the configured max message size
     ///   (64MB by default).

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,15 +40,15 @@ pub enum Error {
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
     /// TLS error
-    #[cfg(feature = "use-native-tls")]
+    #[cfg(feature = "native-tls")]
     #[error("TLS (native-tls) error: {0}")]
-    TlsNative(#[from] native_tls::Error),
+    TlsNative(#[from] native_tls_crate::Error),
     /// TLS error
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "rustls-tls")]
     #[error("TLS (rustls) error: {0}")]
     TlsRustls(#[from] rustls::TLSError),
     /// DNS name resolution error.
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "rustls-tls")]
     #[error("Invalid DNS name: {0}")]
     Dns(#[from] webpki::InvalidDNSNameError),
     /// - When reading: buffer capacity exhausted.

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ pub mod tls {
     pub use native_tls::Error;
 }
 
-#[cfg(feature = "use-rustls")]
+#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
 pub mod tls {
     //! TLS error wrapper module, feature-gated.
     pub use rustls::TLSError as Error;
@@ -50,10 +50,10 @@ pub enum Error {
     #[cfg(feature = "use-native-tls")]
     /// TLS error
     Tls(tls::Error),
-    #[cfg(feature = "use-rustls")]
+    #[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
     /// TLS error
     Tls(tls::Error),
-    #[cfg(feature = "use-rustls")]
+    #[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
     /// DNS name resolution error.
     Dns(tls::DnsError),
     /// - When reading: buffer capacity exhausted.
@@ -82,9 +82,9 @@ impl fmt::Display for Error {
             Error::Io(ref err) => write!(f, "IO error: {}", err),
             #[cfg(feature = "use-native-tls")]
             Error::Tls(ref err) => write!(f, "TLS error: {}", err),
-            #[cfg(feature = "use-rustls")]
+            #[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
             Error::Tls(ref err) => write!(f, "TLS error: {}", err),
-            #[cfg(feature = "use-rustls")]
+            #[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
             Error::Dns(ref err) => write!(f, "Invalid DNS name: {}", err),
             Error::Capacity(ref msg) => write!(f, "Space limit exceeded: {}", msg),
             Error::Protocol(ref msg) => write!(f, "WebSocket protocol error: {}", msg),
@@ -160,14 +160,14 @@ impl From<tls::Error> for Error {
     }
 }
 
-#[cfg(feature = "use-rustls")]
+#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
 impl From<tls::Error> for Error {
     fn from(err: tls::Error) -> Self {
         Error::Tls(err)
     }
 }
 
-#[cfg(feature = "use-rustls")]
+#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
 impl From<tls::DnsError> for Error {
     fn from(err: tls::DnsError) -> Self {
         Error::Dns(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,3 @@ pub use crate::{
     protocol::{Message, WebSocket},
     server::{accept, accept_hdr},
 };
-
-#[cfg(all(feature = "use-native-tls", feature = "use-rustls"))]
-compile_error!("either \"use-native-tls\" or \"use-rustls\" can be enabled, but not both.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,5 +30,5 @@ pub use crate::{
     server::{accept, accept_hdr},
 };
 
-#[cfg(all(feature = "native-tls", feature = "rustls-tls"))]
-compile_error!("either \"native-tls\" or \"rustls-tls\" can be enabled, but not both.");
+#[cfg(all(feature = "use-native-tls", feature = "use-rustls"))]
+compile_error!("either \"use-native-tls\" or \"use-rustls\" can be enabled, but not both.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,3 +29,6 @@ pub use crate::{
     protocol::{Message, WebSocket},
     server::{accept, accept_hdr},
 };
+
+#[cfg(all(feature = "native-tls", feature = "rustls-tls"))]
+compile_error!("either \"native-tls\" or \"rustls-tls\" can be enabled, but not both.");

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,9 +17,9 @@ use std::io::{Read, Write};
 /// used by `accept()`.
 ///
 /// This function starts a server WebSocket handshake over the given stream.
-/// If you want TLS support, use `native_tls::TlsStream` or `openssl::ssl::SslStream`
-/// for the stream here. Any `Read + Write` streams are supported, including
-/// those from `Mio` and others.
+/// If you want TLS support, use `native_tls::TlsStream`, `rustls::Stream` or
+/// `openssl::ssl::SslStream` for the stream here. Any `Read + Write` streams are supported,
+/// including those from `Mio` and others.
 pub fn accept_with_config<S: Read + Write>(
     stream: S,
     config: Option<WebSocketConfig>,
@@ -30,9 +30,9 @@ pub fn accept_with_config<S: Read + Write>(
 /// Accept the given Stream as a WebSocket.
 ///
 /// This function starts a server WebSocket handshake over the given stream.
-/// If you want TLS support, use `native_tls::TlsStream` or `openssl::ssl::SslStream`
-/// for the stream here. Any `Read + Write` streams are supported, including
-/// those from `Mio` and others.
+/// If you want TLS support, use `native_tls::TlsStream`, `rustls::Stream` or
+/// `openssl::ssl::SslStream` for the stream here. Any `Read + Write` streams are supported,
+/// including those from `Mio` and others.
 pub fn accept<S: Read + Write>(
     stream: S,
 ) -> Result<WebSocket<S>, HandshakeError<ServerHandshake<S, NoCallback>>> {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -8,8 +8,10 @@ use std::io::{Read, Result as IoResult, Write};
 
 use std::net::TcpStream;
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls")]
 use native_tls::TlsStream;
+#[cfg(feature = "rustls-tls")]
+use rustls::StreamOwned as TlsStream;
 
 /// Stream mode, either plain TCP or TLS.
 #[derive(Clone, Copy, Debug)]
@@ -32,10 +34,17 @@ impl NoDelay for TcpStream {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls")]
 impl<S: Read + Write + NoDelay> NoDelay for TlsStream<S> {
     fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
         self.get_mut().set_nodelay(nodelay)
+    }
+}
+
+#[cfg(feature = "rustls-tls")]
+impl<S: rustls::Session, T: Read + Write + NoDelay> NoDelay for TlsStream<S, T> {
+    fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
+        self.sock.set_nodelay(nodelay)
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -10,7 +10,7 @@ use std::net::TcpStream;
 
 #[cfg(feature = "use-native-tls")]
 use native_tls::TlsStream;
-#[cfg(feature = "use-rustls")]
+#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
 use rustls::StreamOwned as TlsStream;
 
 /// Stream mode, either plain TCP or TLS.
@@ -41,7 +41,7 @@ impl<S: Read + Write + NoDelay> NoDelay for TlsStream<S> {
     }
 }
 
-#[cfg(feature = "use-rustls")]
+#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
 impl<S: rustls::Session, T: Read + Write + NoDelay> NoDelay for TlsStream<S, T> {
     fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
         self.sock.set_nodelay(nodelay)

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -8,9 +8,9 @@ use std::io::{Read, Result as IoResult, Write};
 
 use std::net::TcpStream;
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "use-native-tls")]
 use native_tls::TlsStream;
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "use-rustls")]
 use rustls::StreamOwned as TlsStream;
 
 /// Stream mode, either plain TCP or TLS.
@@ -34,14 +34,14 @@ impl NoDelay for TcpStream {
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "use-native-tls")]
 impl<S: Read + Write + NoDelay> NoDelay for TlsStream<S> {
     fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
         self.get_mut().set_nodelay(nodelay)
     }
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "use-rustls")]
 impl<S: rustls::Session, T: Read + Write + NoDelay> NoDelay for TlsStream<S, T> {
     fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
         self.sock.set_nodelay(nodelay)

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -10,8 +10,8 @@ use std::net::TcpStream;
 
 #[cfg(feature = "use-native-tls")]
 use native_tls::TlsStream;
-#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
-use rustls::StreamOwned as TlsStream;
+#[cfg(feature = "use-rustls")]
+use rustls::StreamOwned;
 
 /// Stream mode, either plain TCP or TLS.
 #[derive(Clone, Copy, Debug)]
@@ -41,8 +41,8 @@ impl<S: Read + Write + NoDelay> NoDelay for TlsStream<S> {
     }
 }
 
-#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
-impl<S: rustls::Session, T: Read + Write + NoDelay> NoDelay for TlsStream<S, T> {
+#[cfg(feature = "use-rustls")]
+impl<S: rustls::Session, T: Read + Write + NoDelay> NoDelay for StreamOwned<S, T> {
     fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
         self.sock.set_nodelay(nodelay)
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -8,9 +8,9 @@ use std::io::{Read, Result as IoResult, Write};
 
 use std::net::TcpStream;
 
-#[cfg(feature = "use-native-tls")]
-use native_tls::TlsStream;
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "native-tls")]
+use native_tls_crate::TlsStream;
+#[cfg(feature = "rustls-tls")]
 use rustls::StreamOwned;
 
 /// Stream mode, either plain TCP or TLS.
@@ -34,14 +34,14 @@ impl NoDelay for TcpStream {
     }
 }
 
-#[cfg(feature = "use-native-tls")]
+#[cfg(feature = "native-tls")]
 impl<S: Read + Write + NoDelay> NoDelay for TlsStream<S> {
     fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
         self.get_mut().set_nodelay(nodelay)
     }
 }
 
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "rustls-tls")]
 impl<S: rustls::Session, T: Read + Write + NoDelay> NoDelay for StreamOwned<S, T> {
     fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
         self.sock.set_nodelay(nodelay)

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -15,7 +15,7 @@ use url::Url;
 
 #[cfg(feature = "use-native-tls")]
 type Sock = WebSocket<Stream<TcpStream, native_tls::TlsStream<TcpStream>>>;
-#[cfg(feature = "use-rustls")]
+#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
 type Sock = WebSocket<Stream<TcpStream, rustls::StreamOwned<rustls::ClientSession, TcpStream>>>;
 
 fn do_test<CT, ST>(port: u16, client_task: CT, server_task: ST)

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -1,5 +1,6 @@
 //! Verifies that the server returns a `ConnectionClosed` error when the connection
 //! is closedd from the server's point of view and drop the underlying tcp socket.
+#![cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 
 use std::{
     net::{TcpListener, TcpStream},
@@ -8,12 +9,14 @@ use std::{
     time::Duration,
 };
 
-use native_tls::TlsStream;
 use net2::TcpStreamExt;
 use tungstenite::{accept, connect, stream::Stream, Error, Message, WebSocket};
 use url::Url;
 
-type Sock = WebSocket<Stream<TcpStream, TlsStream<TcpStream>>>;
+#[cfg(feature = "native-tls")]
+type Sock = WebSocket<Stream<TcpStream, native_tls::TlsStream<TcpStream>>>;
+#[cfg(feature = "rustls-tls")]
+type Sock = WebSocket<Stream<TcpStream, rustls::StreamOwned<rustls::ClientSession, TcpStream>>>;
 
 fn do_test<CT, ST>(port: u16, client_task: CT, server_task: ST)
 where

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -1,6 +1,6 @@
 //! Verifies that the server returns a `ConnectionClosed` error when the connection
 //! is closedd from the server's point of view and drop the underlying tcp socket.
-#![cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+#![cfg(any(feature = "use-native-tls", feature = "use-rustls"))]
 
 use std::{
     net::{TcpListener, TcpStream},
@@ -13,9 +13,9 @@ use net2::TcpStreamExt;
 use tungstenite::{accept, connect, stream::Stream, Error, Message, WebSocket};
 use url::Url;
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "use-native-tls")]
 type Sock = WebSocket<Stream<TcpStream, native_tls::TlsStream<TcpStream>>>;
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "use-rustls")]
 type Sock = WebSocket<Stream<TcpStream, rustls::StreamOwned<rustls::ClientSession, TcpStream>>>;
 
 fn do_test<CT, ST>(port: u16, client_task: CT, server_task: ST)

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -1,6 +1,6 @@
 //! Verifies that the server returns a `ConnectionClosed` error when the connection
 //! is closed from the server's point of view and drop the underlying tcp socket.
-#![cfg(any(feature = "use-native-tls", feature = "use-rustls"))]
+#![cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 
 use std::{
     net::{TcpListener, TcpStream},
@@ -13,9 +13,9 @@ use net2::TcpStreamExt;
 use tungstenite::{accept, connect, stream::Stream, Error, Message, WebSocket};
 use url::Url;
 
-#[cfg(feature = "use-native-tls")]
-type Sock = WebSocket<Stream<TcpStream, native_tls::TlsStream<TcpStream>>>;
-#[cfg(all(feature = "use-rustls", not(feature = "use-native-tls")))]
+#[cfg(feature = "native-tls")]
+type Sock = WebSocket<Stream<TcpStream, native_tls_crate::TlsStream<TcpStream>>>;
+#[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
 type Sock = WebSocket<Stream<TcpStream, rustls::StreamOwned<rustls::ClientSession, TcpStream>>>;
 
 fn do_test<CT, ST>(port: u16, client_task: CT, server_task: ST)

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -1,5 +1,5 @@
 //! Verifies that the server returns a `ConnectionClosed` error when the connection
-//! is closedd from the server's point of view and drop the underlying tcp socket.
+//! is closed from the server's point of view and drop the underlying tcp socket.
 #![cfg(any(feature = "use-native-tls", feature = "use-rustls"))]
 
 use std::{


### PR DESCRIPTION
This PR adds `rustls` as an alternative to the current `native-tls`. In addition, I changed the default feature set to not include any TLS implementation which is a breaking change as people have to add the TLS feature explicitly now.

I'm not sure what way you prefer to have the feature set so I will adjust to the way you prefer once you let me know.

Resolves #89.