### PR TITLE
Create specific error types for protocol, URL, and capacity errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # 0.13.0
 
-- Add `thiserror` to dependencies.
-- Modify `Error` to be implemented using the `thiserror::Error` derive macro.
 - Add `CapacityError`, `UrlError`, and `ProtocolError` types to represent the different types of capacity, URL, and protocol errors respectively.
 - Modify variants `Error::Capacity`, `Error::Url`, and `Error::Protocol` to hold the above errors types instead of string error messages.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.13.0
+
+- Add `thiserror` to dependencies.
+- Modify `Error` to be implemented using the `thiserror::Error` derive macro.
+- Add `CapacityError`, `UrlError`, and `ProtocolError` types to represent the different types of capacity, URL, and protocol errors respectively.
+- Modify variants `Error::Capacity`, `Error::Url`, and `Error::Protocol` to hold the above errors types instead of string error messages.
+
 # 0.12.0
 
 - Add facilities to allow clients to follow HTTP 3XX redirects.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/snapview/tungstenite-rs"
 documentation = "https://docs.rs/tungstenite/0.12.0"
 repository = "https://github.com/snapview/tungstenite-rs"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2018"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rand = "0.8.0"
 sha-1 = "0.9"
 url = "2.1.0"
 utf-8 = "0.7.5"
+thiserror = "1.0.23"
 
 [dependencies.native-tls]
 optional = true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ fn main () {
             let mut websocket = accept(stream.unwrap()).unwrap();
             loop {
                 let msg = websocket.read_message().unwrap();
-    
+
                 // We do not want to send back ping/pong messages.
                 if msg.is_binary() || msg.is_text() {
                     websocket.write_message(msg).unwrap();
@@ -64,7 +64,7 @@ Testing
 -------
 
 Tungstenite is thoroughly tested and passes the [Autobahn Test Suite](https://crossbar.io/autobahn/) for
-WebSockets. It is also covered by internal unit tests as good as possible.
+WebSockets. It is also covered by internal unit tests as well as possible.
 
 Contributing
 ------------

--- a/src/client.rs
+++ b/src/client.rs
@@ -52,7 +52,7 @@ mod encryption {
     use std::net::TcpStream;
 
     use crate::{
-        error::{Error, UrlErrorType, Result},
+        error::{Error, Result, UrlErrorType},
         stream::Mode,
     };
 
@@ -71,7 +71,7 @@ use self::encryption::wrap_stream;
 pub use self::encryption::AutoStream;
 
 use crate::{
-    error::{Error, UrlErrorType, Result},
+    error::{Error, Result, UrlErrorType},
     handshake::{client::ClientHandshake, HandshakeError},
     protocol::WebSocket,
     stream::{Mode, NoDelay},
@@ -103,8 +103,7 @@ pub fn connect_with_config<Req: IntoClientRequest>(
     ) -> Result<(WebSocket<AutoStream>, Response)> {
         let uri = request.uri();
         let mode = uri_mode(uri)?;
-        let host =
-            request.uri().host().ok_or_else(|| Error::Url(UrlErrorType::NoHostName))?;
+        let host = request.uri().host().ok_or_else(|| Error::Url(UrlErrorType::NoHostName))?;
         let port = uri.port_u16().unwrap_or(match mode {
             Mode::Plain => 80,
             Mode::Tls => 443,

--- a/src/client.rs
+++ b/src/client.rs
@@ -52,7 +52,7 @@ mod encryption {
     use std::net::TcpStream;
 
     use crate::{
-        error::{Error, Result, UrlErrorType},
+        error::{Error, Result, UrlError},
         stream::Mode,
     };
 
@@ -62,7 +62,7 @@ mod encryption {
     pub fn wrap_stream(stream: TcpStream, _domain: &str, mode: Mode) -> Result<AutoStream> {
         match mode {
             Mode::Plain => Ok(stream),
-            Mode::Tls => Err(Error::Url(UrlErrorType::TlsFeatureNotEnabled)),
+            Mode::Tls => Err(Error::Url(UrlError::TlsFeatureNotEnabled)),
         }
     }
 }
@@ -71,7 +71,7 @@ use self::encryption::wrap_stream;
 pub use self::encryption::AutoStream;
 
 use crate::{
-    error::{Error, Result, UrlErrorType},
+    error::{Error, Result, UrlError},
     handshake::{client::ClientHandshake, HandshakeError},
     protocol::WebSocket,
     stream::{Mode, NoDelay},
@@ -103,7 +103,7 @@ pub fn connect_with_config<Req: IntoClientRequest>(
     ) -> Result<(WebSocket<AutoStream>, Response)> {
         let uri = request.uri();
         let mode = uri_mode(uri)?;
-        let host = request.uri().host().ok_or(Error::Url(UrlErrorType::NoHostName))?;
+        let host = request.uri().host().ok_or(Error::Url(UrlError::NoHostName))?;
         let port = uri.port_u16().unwrap_or(match mode {
             Mode::Plain => 80,
             Mode::Tls => 443,
@@ -165,7 +165,7 @@ pub fn connect<Req: IntoClientRequest>(request: Req) -> Result<(WebSocket<AutoSt
 }
 
 fn connect_to_some(addrs: &[SocketAddr], uri: &Uri, mode: Mode) -> Result<AutoStream> {
-    let domain = uri.host().ok_or(Error::Url(UrlErrorType::NoHostName))?;
+    let domain = uri.host().ok_or(Error::Url(UrlError::NoHostName))?;
     for addr in addrs {
         debug!("Trying to contact {} at {}...", uri, addr);
         if let Ok(raw_stream) = TcpStream::connect(addr) {
@@ -174,7 +174,7 @@ fn connect_to_some(addrs: &[SocketAddr], uri: &Uri, mode: Mode) -> Result<AutoSt
             }
         }
     }
-    Err(Error::Url(UrlErrorType::UnableToConnect(uri.to_string())))
+    Err(Error::Url(UrlError::UnableToConnect(uri.to_string())))
 }
 
 /// Get the mode of the given URL.
@@ -185,7 +185,7 @@ pub fn uri_mode(uri: &Uri) -> Result<Mode> {
     match uri.scheme_str() {
         Some("ws") => Ok(Mode::Plain),
         Some("wss") => Ok(Mode::Tls),
-        _ => Err(Error::Url(UrlErrorType::UnsupportedUrlScheme)),
+        _ => Err(Error::Url(UrlError::UnsupportedUrlScheme)),
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -103,7 +103,7 @@ pub fn connect_with_config<Req: IntoClientRequest>(
     ) -> Result<(WebSocket<AutoStream>, Response)> {
         let uri = request.uri();
         let mode = uri_mode(uri)?;
-        let host = request.uri().host().ok_or_else(|| Error::Url(UrlErrorType::NoHostName))?;
+        let host = request.uri().host().ok_or(Error::Url(UrlErrorType::NoHostName))?;
         let port = uri.port_u16().unwrap_or(match mode {
             Mode::Plain => 80,
             Mode::Tls => 443,
@@ -165,7 +165,7 @@ pub fn connect<Req: IntoClientRequest>(request: Req) -> Result<(WebSocket<AutoSt
 }
 
 fn connect_to_some(addrs: &[SocketAddr], uri: &Uri, mode: Mode) -> Result<AutoStream> {
-    let domain = uri.host().ok_or_else(|| Error::Url(UrlErrorType::NoHostName))?;
+    let domain = uri.host().ok_or(Error::Url(UrlErrorType::NoHostName))?;
     for addr in addrs {
         debug!("Trying to contact {} at {}...", uri, addr);
         if let Ok(raw_stream) = TcpStream::connect(addr) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Error handling.
 
-use std::{fmt, io, result, str, string};
+use std::{io, result, str, string};
 
 use crate::protocol::{frame::coding::Data, Message};
 use http::Response;
@@ -44,8 +44,8 @@ pub enum Error {
     /// underlying connection and you should probably consider them fatal.
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
-    #[cfg(feature = "tls")]
     /// TLS error.
+    #[cfg(feature = "tls")]
     #[error("TLS error: {0}")]
     Tls(#[from] tls::Error),
     /// - When reading: buffer capacity exhausted.
@@ -59,12 +59,12 @@ pub enum Error {
     /// Message send queue full.
     #[error("Send queue is full")]
     SendQueueFull(Message),
-    /// UTF coding error
+    /// UTF coding error.
     #[error("UTF-8 encoding error")]
     Utf8,
     /// Invalid URL.
     #[error("URL error: {0}")]
-    Url(UrlErrorType),
+    Url(UrlError),
     /// HTTP error.
     #[error("HTTP error: {}", .0.status())]
     Http(Response<Option<String>>),
@@ -227,31 +227,24 @@ pub enum ProtocolError {
 }
 
 /// Indicates the specific type/cause of URL error.
-#[derive(Debug, PartialEq, Eq)]
-pub enum UrlErrorType {
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum UrlError {
     /// TLS is used despite not being compiled with the TLS feature enabled.
+    #[error("TLS support not compiled in")]
     TlsFeatureNotEnabled,
     /// The URL does not include a host name.
+    #[error("No host name in the URL")]
     NoHostName,
     /// Failed to connect with this URL.
+    #[error("Unable to connect to {0}")]
     UnableToConnect(String),
     /// Unsupported URL scheme used (only `ws://` or `wss://` may be used).
+    #[error("URL scheme not supported")]
     UnsupportedUrlScheme,
     /// The URL host name, though included, is empty.
+    #[error("URL contains empty host name")]
     EmptyHostName,
     /// The URL does not include a path/query.
+    #[error("No path/query in URL")]
     NoPathOrQuery,
-}
-
-impl fmt::Display for UrlErrorType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            UrlErrorType::TlsFeatureNotEnabled => write!(f, "TLS support not compiled in"),
-            UrlErrorType::NoHostName => write!(f, "No host name in the URL"),
-            UrlErrorType::UnableToConnect(uri) => write!(f, "Unable to connect to {}", uri),
-            UrlErrorType::UnsupportedUrlScheme => write!(f, "URL scheme not supported"),
-            UrlErrorType::EmptyHostName => write!(f, "URL contains empty host name"),
-            UrlErrorType::NoPathOrQuery => write!(f, "No path/query in URL"),
-        }
-    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 
 use std::{borrow::Cow, error::Error as ErrorTrait, fmt, io, result, str, string};
 
-use crate::protocol::Message;
+use crate::protocol::{frame::coding::Data, Message};
 use http::Response;
 
 #[cfg(feature = "tls")]
@@ -41,14 +41,14 @@ pub enum Error {
     /// underlying connection and you should probably consider them fatal.
     Io(io::Error),
     #[cfg(feature = "tls")]
-    /// TLS error
+    /// TLS error.
     Tls(tls::Error),
     /// - When reading: buffer capacity exhausted.
     /// - When writing: your message is bigger than the configured max message size
     ///   (64MB by default).
     Capacity(Cow<'static, str>),
     /// Protocol violation.
-    Protocol(Cow<'static, str>),
+    Protocol(ProtocolErrorType),
     /// Message send queue full.
     SendQueueFull(Message),
     /// UTF coding error
@@ -147,13 +147,13 @@ impl From<httparse::Error> for Error {
     fn from(err: httparse::Error) -> Self {
         match err {
             httparse::Error::TooManyHeaders => Error::Capacity("Too many headers".into()),
-            e => Error::Protocol(e.to_string().into()),
+            e => Error::Protocol(ProtocolErrorType::HttparseError(e)),
         }
     }
 }
 
 /// Indicates the specific type/cause of URL error.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum UrlErrorType {
     /// TLS is used despite not being compiled with the TLS feature enabled.
     TlsFeatureNotEnabled,
@@ -166,7 +166,7 @@ pub enum UrlErrorType {
     /// The URL host name, though included, is empty.
     EmptyHostName,
     /// The URL does not include a path/query.
-    NoPathOrQuery
+    NoPathOrQuery,
 }
 
 impl fmt::Display for UrlErrorType {
@@ -177,7 +177,128 @@ impl fmt::Display for UrlErrorType {
             UrlErrorType::UnableToConnect(uri) => write!(f, "Unable to connect to {}", uri),
             UrlErrorType::UnsupportedUrlScheme => write!(f, "URL scheme not supported"),
             UrlErrorType::EmptyHostName => write!(f, "URL contains empty host name"),
-            UrlErrorType::NoPathOrQuery => write!(f, "No path/query in URL")
+            UrlErrorType::NoPathOrQuery => write!(f, "No path/query in URL"),
+        }
+    }
+}
+
+/// Indicates the specific type/cause of a protocol error.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ProtocolErrorType {
+    /// Use of the wrong HTTP method (the WebSocket protocol requires the GET method be used).
+    WrongHttpMethod,
+    /// Wrong HTTP version used (the WebSocket protocol requires version 1.1 or higher).
+    WrongHttpVersion,
+    /// Missing `Connection: upgrade` HTTP header.
+    MissingConnectionUpgradeHeader,
+    /// Missing `Upgrade: websocket` HTTP header.
+    MissingUpgradeWebSocketHeader,
+    /// Missing `Sec-WebSocket-Version: 13` HTTP header.
+    MissingSecWebSocketVersionHeader,
+    /// Missing `Sec-WebSocket-Key` HTTP header.
+    MissingSecWebSocketKey,
+    /// The `Sec-WebSocket-Accept` header is either not present or does not specify the correct key value.
+    SecWebSocketAcceptKeyMismatch,
+    /// Garbage data encountered after client request.
+    JunkAfterRequest,
+    /// Custom responses must be unsuccessful.
+    CustomResponseSuccessful,
+    /// No more data while still performing handshake.
+    HandshakeIncomplete,
+    /// Wrapper around a [`httparse::Error`] value.
+    HttparseError(httparse::Error),
+    /// Not allowed to send after having sent a closing frame.
+    SendAfterClosing,
+    /// Remote sent data after sending a closing frame.
+    ReceivedAfterClosing,
+    /// Reserved bits in frame header are non-zero.
+    NonZeroReservedBits,
+    /// The server must close the connection when an unmasked frame is received.
+    UnmaskedFrameFromClient,
+    /// The client must close the connection when a masked frame is received.
+    MaskedFrameFromServer,
+    /// Control frames must not be fragmented.
+    FragmentedControlFrame,
+    /// Control frames must have a payload of 125 bytes or less.
+    ControlFrameTooBig,
+    /// Type of control frame not recognised.
+    UnknownControlFrameType(u8),
+    /// Type of data frame not recognised.
+    UnknownDataFrameType(u8),
+    /// Received a continue frame despite there being nothing to continue.
+    UnexpectedContinueFrame,
+    /// Received data while waiting for more fragments.
+    ExpectedFragment(Data),
+    /// Connection closed without performing the closing handshake.
+    ResetWithoutClosingHandshake,
+    /// Encountered an invalid opcode.
+    InvalidOpcode(u8),
+    /// The payload for the closing frame is invalid.
+    InvalidCloseSequence,
+}
+
+impl fmt::Display for ProtocolErrorType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ProtocolErrorType::WrongHttpMethod => {
+                write!(f, "Unsupported HTTP method used, only GET is allowed")
+            }
+            ProtocolErrorType::WrongHttpVersion => write!(f, "HTTP version must be 1.1 or higher"),
+            ProtocolErrorType::MissingConnectionUpgradeHeader => {
+                write!(f, "No \"Connection: upgrade\" header")
+            }
+            ProtocolErrorType::MissingUpgradeWebSocketHeader => {
+                write!(f, "No \"Upgrade: websocket\" header")
+            }
+            ProtocolErrorType::MissingSecWebSocketVersionHeader => {
+                write!(f, "No \"Sec-WebSocket-Version: 13\" header")
+            }
+            ProtocolErrorType::MissingSecWebSocketKey => {
+                write!(f, "No \"Sec-WebSocket-Key\" header")
+            }
+            ProtocolErrorType::SecWebSocketAcceptKeyMismatch => {
+                write!(f, "Key mismatch in \"Sec-WebSocket-Accept\" header")
+            }
+            ProtocolErrorType::JunkAfterRequest => write!(f, "Junk after client request"),
+            ProtocolErrorType::CustomResponseSuccessful => {
+                write!(f, "Custom response must not be successful")
+            }
+            ProtocolErrorType::HandshakeIncomplete => write!(f, "Handshake not finished"),
+            ProtocolErrorType::HttparseError(e) => write!(f, "httparse error: {}", e),
+            ProtocolErrorType::SendAfterClosing => {
+                write!(f, "Sending after closing is not allowed")
+            }
+            ProtocolErrorType::ReceivedAfterClosing => write!(f, "Remote sent after having closed"),
+            ProtocolErrorType::NonZeroReservedBits => write!(f, "Reserved bits are non-zero"),
+            ProtocolErrorType::UnmaskedFrameFromClient => {
+                write!(f, "Received an unmasked frame from client")
+            }
+            ProtocolErrorType::MaskedFrameFromServer => {
+                write!(f, "Received a masked frame from server")
+            }
+            ProtocolErrorType::FragmentedControlFrame => write!(f, "Fragmented control frame"),
+            ProtocolErrorType::ControlFrameTooBig => {
+                write!(f, "Control frame too big (payload must be 125 bytes or less)")
+            }
+            ProtocolErrorType::UnknownControlFrameType(i) => {
+                write!(f, "Unknown control frame type: {}", i)
+            }
+            ProtocolErrorType::UnknownDataFrameType(i) => {
+                write!(f, "Unknown data frame type: {}", i)
+            }
+            ProtocolErrorType::UnexpectedContinueFrame => {
+                write!(f, "Continue frame but nothing to continue")
+            }
+            ProtocolErrorType::ExpectedFragment(c) => {
+                write!(f, "While waiting for more fragments received: {}", c)
+            }
+            ProtocolErrorType::ResetWithoutClosingHandshake => {
+                write!(f, "Connection reset without closing handshake")
+            }
+            ProtocolErrorType::InvalidOpcode(opcode) => {
+                write!(f, "Encountered invalid opcode: {}", opcode)
+            }
+            ProtocolErrorType::InvalidCloseSequence => write!(f, "Invalid close sequence"),
         }
     }
 }

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -16,7 +16,7 @@ use super::{
     HandshakeRole, MidHandshake, ProcessingResult,
 };
 use crate::{
-    error::{Error, UrlErrorType, Result},
+    error::{Error, ProtocolErrorType, Result, UrlErrorType},
     protocol::{Role, WebSocket, WebSocketConfig},
 };
 
@@ -42,11 +42,11 @@ impl<S: Read + Write> ClientHandshake<S> {
         config: Option<WebSocketConfig>,
     ) -> Result<MidHandshake<Self>> {
         if request.method() != http::Method::GET {
-            return Err(Error::Protocol("Invalid HTTP method, only GET supported".into()));
+            return Err(Error::Protocol(ProtocolErrorType::WrongHttpMethod));
         }
 
         if request.version() < http::Version::HTTP_11 {
-            return Err(Error::Protocol("HTTP version should be 1.1 or higher".into()));
+            return Err(Error::Protocol(ProtocolErrorType::WrongHttpVersion));
         }
 
         // Check the URI scheme: only ws or wss are supported
@@ -97,8 +97,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
     let mut req = Vec::new();
     let uri = request.uri();
 
-    let authority =
-        uri.authority().ok_or_else(|| Error::Url(UrlErrorType::NoHostName))?.as_str();
+    let authority = uri.authority().ok_or_else(|| Error::Url(UrlErrorType::NoHostName))?.as_str();
     let host = if let Some(idx) = authority.find('@') {
         // handle possible name:password@
         authority.split_at(idx + 1).1
@@ -165,7 +164,7 @@ impl VerifyData {
             .map(|h| h.eq_ignore_ascii_case("websocket"))
             .unwrap_or(false)
         {
-            return Err(Error::Protocol("No \"Upgrade: websocket\" in server reply".into()));
+            return Err(Error::Protocol(ProtocolErrorType::MissingUpgradeWebSocketHeader));
         }
         // 3.  If the response lacks a |Connection| header field or the
         // |Connection| header field doesn't contain a token that is an
@@ -177,14 +176,14 @@ impl VerifyData {
             .map(|h| h.eq_ignore_ascii_case("Upgrade"))
             .unwrap_or(false)
         {
-            return Err(Error::Protocol("No \"Connection: upgrade\" in server reply".into()));
+            return Err(Error::Protocol(ProtocolErrorType::MissingConnectionUpgradeHeader));
         }
         // 4.  If the response lacks a |Sec-WebSocket-Accept| header field or
         // the |Sec-WebSocket-Accept| contains a value other than the
         // base64-encoded SHA-1 of ... the client MUST _Fail the WebSocket
         // Connection_. (RFC 6455)
         if !headers.get("Sec-WebSocket-Accept").map(|h| h == &self.accept_key).unwrap_or(false) {
-            return Err(Error::Protocol("Key mismatch in Sec-WebSocket-Accept".into()));
+            return Err(Error::Protocol(ProtocolErrorType::SecWebSocketAcceptKeyMismatch));
         }
         // 5.  If the response includes a |Sec-WebSocket-Extensions| header
         // field and this header field indicates the use of an extension
@@ -218,7 +217,7 @@ impl TryParse for Response {
 impl<'h, 'b: 'h> FromHttparse<httparse::Response<'h, 'b>> for Response {
     fn from_httparse(raw: httparse::Response<'h, 'b>) -> Result<Self> {
         if raw.version.expect("Bug: no HTTP version") < /*1.*/1 {
-            return Err(Error::Protocol("HTTP version should be 1.1 or higher".into()));
+            return Err(Error::Protocol(ProtocolErrorType::WrongHttpMethod));
         }
 
         let headers = HeaderMap::from_httparse(raw.headers)?;

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -16,7 +16,7 @@ use super::{
     HandshakeRole, MidHandshake, ProcessingResult,
 };
 use crate::{
-    error::{Error, ProtocolError, Result, UrlErrorType},
+    error::{Error, ProtocolError, Result, UrlError},
     protocol::{Role, WebSocket, WebSocketConfig},
 };
 
@@ -97,7 +97,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
     let mut req = Vec::new();
     let uri = request.uri();
 
-    let authority = uri.authority().ok_or(Error::Url(UrlErrorType::NoHostName))?.as_str();
+    let authority = uri.authority().ok_or(Error::Url(UrlError::NoHostName))?.as_str();
     let host = if let Some(idx) = authority.find('@') {
         // handle possible name:password@
         authority.split_at(idx + 1).1
@@ -105,7 +105,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
         authority
     };
     if authority.is_empty() {
-        return Err(Error::Url(UrlErrorType::EmptyHostName));
+        return Err(Error::Url(UrlError::EmptyHostName));
     }
 
     write!(
@@ -119,7 +119,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
          Sec-WebSocket-Key: {key}\r\n",
         version = request.version(),
         host = host,
-        path = uri.path_and_query().ok_or(Error::Url(UrlErrorType::NoPathOrQuery))?.as_str(),
+        path = uri.path_and_query().ok_or(Error::Url(UrlError::NoPathOrQuery))?.as_str(),
         key = key
     )
     .unwrap();

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -16,7 +16,7 @@ use super::{
     HandshakeRole, MidHandshake, ProcessingResult,
 };
 use crate::{
-    error::{Error, Result},
+    error::{Error, UrlErrorType, Result},
     protocol::{Role, WebSocket, WebSocketConfig},
 };
 
@@ -98,7 +98,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
     let uri = request.uri();
 
     let authority =
-        uri.authority().ok_or_else(|| Error::Url("No host name in the URL".into()))?.as_str();
+        uri.authority().ok_or_else(|| Error::Url(UrlErrorType::NoHostName))?.as_str();
     let host = if let Some(idx) = authority.find('@') {
         // handle possible name:password@
         authority.split_at(idx + 1).1
@@ -106,7 +106,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
         authority
     };
     if authority.is_empty() {
-        return Err(Error::Url("URL contains empty host name".into()));
+        return Err(Error::Url(UrlErrorType::EmptyHostName));
     }
 
     write!(
@@ -121,7 +121,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
         version = request.version(),
         host = host,
         path =
-            uri.path_and_query().ok_or_else(|| Error::Url("No path/query in URL".into()))?.as_str(),
+            uri.path_and_query().ok_or_else(|| Error::Url(UrlErrorType::NoPathOrQuery))?.as_str(),
         key = key
     )
     .unwrap();

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -97,7 +97,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
     let mut req = Vec::new();
     let uri = request.uri();
 
-    let authority = uri.authority().ok_or_else(|| Error::Url(UrlErrorType::NoHostName))?.as_str();
+    let authority = uri.authority().ok_or(Error::Url(UrlErrorType::NoHostName))?.as_str();
     let host = if let Some(idx) = authority.find('@') {
         // handle possible name:password@
         authority.split_at(idx + 1).1
@@ -119,8 +119,7 @@ fn generate_request(request: Request, key: &str) -> Result<Vec<u8>> {
          Sec-WebSocket-Key: {key}\r\n",
         version = request.version(),
         host = host,
-        path =
-            uri.path_and_query().ok_or_else(|| Error::Url(UrlErrorType::NoPathOrQuery))?.as_str(),
+        path = uri.path_and_query().ok_or(Error::Url(UrlErrorType::NoPathOrQuery))?.as_str(),
         key = key
     )
     .unwrap();

--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -3,7 +3,7 @@ use log::*;
 use std::io::{Cursor, Read, Write};
 
 use crate::{
-    error::{Error, Result},
+    error::{Error, ProtocolErrorType, Result},
     util::NonBlockingResult,
 };
 use input_buffer::{InputBuffer, MIN_READ};
@@ -50,7 +50,7 @@ impl<Stream: Read + Write> HandshakeMachine<Stream> {
                     .read_from(&mut self.stream)
                     .no_block()?;
                 match read {
-                    Some(0) => Err(Error::Protocol("Handshake not finished".into())),
+                    Some(0) => Err(Error::Protocol(ProtocolErrorType::HandshakeIncomplete)),
                     Some(_) => Ok(if let Some((size, obj)) = Obj::try_parse(Buf::chunk(&buf))? {
                         buf.advance(size);
                         RoundResult::StageFinished(StageResult::DoneReading {

--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -3,7 +3,7 @@ use log::*;
 use std::io::{Cursor, Read, Write};
 
 use crate::{
-    error::{CapacityErrorType, Error, ProtocolErrorType, Result},
+    error::{CapacityError, Error, ProtocolErrorType, Result},
     util::NonBlockingResult,
 };
 use input_buffer::{InputBuffer, MIN_READ};
@@ -46,7 +46,7 @@ impl<Stream: Read + Write> HandshakeMachine<Stream> {
                 let read = buf
                     .prepare_reserve(MIN_READ)
                     .with_limit(usize::max_value()) // TODO limit size
-                    .map_err(|_| Error::Capacity(CapacityErrorType::HeaderTooLong))?
+                    .map_err(|_| Error::Capacity(CapacityError::HeaderTooLong))?
                     .read_from(&mut self.stream)
                     .no_block()?;
                 match read {

--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -3,7 +3,7 @@ use log::*;
 use std::io::{Cursor, Read, Write};
 
 use crate::{
-    error::{Error, ProtocolErrorType, Result},
+    error::{CapacityErrorType, Error, ProtocolErrorType, Result},
     util::NonBlockingResult,
 };
 use input_buffer::{InputBuffer, MIN_READ};
@@ -46,7 +46,7 @@ impl<Stream: Read + Write> HandshakeMachine<Stream> {
                 let read = buf
                     .prepare_reserve(MIN_READ)
                     .with_limit(usize::max_value()) // TODO limit size
-                    .map_err(|_| Error::Capacity("Header too long".into()))?
+                    .map_err(|_| Error::Capacity(CapacityErrorType::HeaderTooLong))?
                     .read_from(&mut self.stream)
                     .no_block()?;
                 match read {

--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -3,7 +3,7 @@ use log::*;
 use std::io::{Cursor, Read, Write};
 
 use crate::{
-    error::{CapacityError, Error, ProtocolErrorType, Result},
+    error::{CapacityError, Error, ProtocolError, Result},
     util::NonBlockingResult,
 };
 use input_buffer::{InputBuffer, MIN_READ};
@@ -50,7 +50,7 @@ impl<Stream: Read + Write> HandshakeMachine<Stream> {
                     .read_from(&mut self.stream)
                     .no_block()?;
                 match read {
-                    Some(0) => Err(Error::Protocol(ProtocolErrorType::HandshakeIncomplete)),
+                    Some(0) => Err(Error::Protocol(ProtocolError::HandshakeIncomplete)),
                     Some(_) => Ok(if let Some((size, obj)) = Obj::try_parse(Buf::chunk(&buf))? {
                         buf.advance(size);
                         RoundResult::StageFinished(StageResult::DoneReading {

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -19,7 +19,7 @@ use super::{
     HandshakeRole, MidHandshake, ProcessingResult,
 };
 use crate::{
-    error::{Error, ProtocolErrorType, Result},
+    error::{Error, ProtocolError, Result},
     protocol::{Role, WebSocket, WebSocketConfig},
 };
 
@@ -34,11 +34,11 @@ pub type ErrorResponse = HttpResponse<Option<String>>;
 
 fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
     if request.method() != http::Method::GET {
-        return Err(Error::Protocol(ProtocolErrorType::WrongHttpMethod));
+        return Err(Error::Protocol(ProtocolError::WrongHttpMethod));
     }
 
     if request.version() < http::Version::HTTP_11 {
-        return Err(Error::Protocol(ProtocolErrorType::WrongHttpVersion));
+        return Err(Error::Protocol(ProtocolError::WrongHttpVersion));
     }
 
     if !request
@@ -48,7 +48,7 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
         .map(|h| h.split(|c| c == ' ' || c == ',').any(|p| p.eq_ignore_ascii_case("Upgrade")))
         .unwrap_or(false)
     {
-        return Err(Error::Protocol(ProtocolErrorType::MissingConnectionUpgradeHeader));
+        return Err(Error::Protocol(ProtocolError::MissingConnectionUpgradeHeader));
     }
 
     if !request
@@ -58,17 +58,17 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
         .map(|h| h.eq_ignore_ascii_case("websocket"))
         .unwrap_or(false)
     {
-        return Err(Error::Protocol(ProtocolErrorType::MissingUpgradeWebSocketHeader));
+        return Err(Error::Protocol(ProtocolError::MissingUpgradeWebSocketHeader));
     }
 
     if !request.headers().get("Sec-WebSocket-Version").map(|h| h == "13").unwrap_or(false) {
-        return Err(Error::Protocol(ProtocolErrorType::MissingSecWebSocketVersionHeader));
+        return Err(Error::Protocol(ProtocolError::MissingSecWebSocketVersionHeader));
     }
 
     let key = request
         .headers()
         .get("Sec-WebSocket-Key")
-        .ok_or(Error::Protocol(ProtocolErrorType::MissingSecWebSocketKey))?;
+        .ok_or(Error::Protocol(ProtocolError::MissingSecWebSocketKey))?;
 
     let builder = Response::builder()
         .status(StatusCode::SWITCHING_PROTOCOLS)
@@ -125,11 +125,11 @@ impl TryParse for Request {
 impl<'h, 'b: 'h> FromHttparse<httparse::Request<'h, 'b>> for Request {
     fn from_httparse(raw: httparse::Request<'h, 'b>) -> Result<Self> {
         if raw.method.expect("Bug: no method in header") != "GET" {
-            return Err(Error::Protocol(ProtocolErrorType::WrongHttpMethod));
+            return Err(Error::Protocol(ProtocolError::WrongHttpMethod));
         }
 
         if raw.version.expect("Bug: no HTTP version") < /*1.*/1 {
-            return Err(Error::Protocol(ProtocolErrorType::WrongHttpVersion));
+            return Err(Error::Protocol(ProtocolError::WrongHttpVersion));
         }
 
         let headers = HeaderMap::from_httparse(raw.headers)?;
@@ -237,7 +237,7 @@ impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
         Ok(match finish {
             StageResult::DoneReading { stream, result, tail } => {
                 if !tail.is_empty() {
-                    return Err(Error::Protocol(ProtocolErrorType::JunkAfterRequest));
+                    return Err(Error::Protocol(ProtocolError::JunkAfterRequest));
                 }
 
                 let response = create_response(&result)?;
@@ -256,9 +256,7 @@ impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
 
                     Err(resp) => {
                         if resp.status().is_success() {
-                            return Err(Error::Protocol(
-                                ProtocolErrorType::CustomResponseSuccessful,
-                            ));
+                            return Err(Error::Protocol(ProtocolError::CustomResponseSuccessful));
                         }
 
                         self.error_response = Some(resp);

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -19,7 +19,7 @@ use super::{
     HandshakeRole, MidHandshake, ProcessingResult,
 };
 use crate::{
-    error::{Error, Result},
+    error::{Error, ProtocolErrorType, Result},
     protocol::{Role, WebSocket, WebSocketConfig},
 };
 
@@ -34,11 +34,11 @@ pub type ErrorResponse = HttpResponse<Option<String>>;
 
 fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
     if request.method() != http::Method::GET {
-        return Err(Error::Protocol("Method is not GET".into()));
+        return Err(Error::Protocol(ProtocolErrorType::WrongHttpMethod));
     }
 
     if request.version() < http::Version::HTTP_11 {
-        return Err(Error::Protocol("HTTP version should be 1.1 or higher".into()));
+        return Err(Error::Protocol(ProtocolErrorType::WrongHttpVersion));
     }
 
     if !request
@@ -48,7 +48,7 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
         .map(|h| h.split(|c| c == ' ' || c == ',').any(|p| p.eq_ignore_ascii_case("Upgrade")))
         .unwrap_or(false)
     {
-        return Err(Error::Protocol("No \"Connection: upgrade\" in client request".into()));
+        return Err(Error::Protocol(ProtocolErrorType::MissingConnectionUpgradeHeader));
     }
 
     if !request
@@ -58,17 +58,17 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
         .map(|h| h.eq_ignore_ascii_case("websocket"))
         .unwrap_or(false)
     {
-        return Err(Error::Protocol("No \"Upgrade: websocket\" in client request".into()));
+        return Err(Error::Protocol(ProtocolErrorType::MissingUpgradeWebSocketHeader));
     }
 
     if !request.headers().get("Sec-WebSocket-Version").map(|h| h == "13").unwrap_or(false) {
-        return Err(Error::Protocol("No \"Sec-WebSocket-Version: 13\" in client request".into()));
+        return Err(Error::Protocol(ProtocolErrorType::MissingSecWebSocketVersionHeader));
     }
 
     let key = request
         .headers()
         .get("Sec-WebSocket-Key")
-        .ok_or_else(|| Error::Protocol("Missing Sec-WebSocket-Key".into()))?;
+        .ok_or_else(|| Error::Protocol(ProtocolErrorType::MissingSecWebSocketKey))?;
 
     let builder = Response::builder()
         .status(StatusCode::SWITCHING_PROTOCOLS)
@@ -125,11 +125,11 @@ impl TryParse for Request {
 impl<'h, 'b: 'h> FromHttparse<httparse::Request<'h, 'b>> for Request {
     fn from_httparse(raw: httparse::Request<'h, 'b>) -> Result<Self> {
         if raw.method.expect("Bug: no method in header") != "GET" {
-            return Err(Error::Protocol("Method is not GET".into()));
+            return Err(Error::Protocol(ProtocolErrorType::WrongHttpMethod));
         }
 
         if raw.version.expect("Bug: no HTTP version") < /*1.*/1 {
-            return Err(Error::Protocol("HTTP version should be 1.1 or higher".into()));
+            return Err(Error::Protocol(ProtocolErrorType::WrongHttpVersion));
         }
 
         let headers = HeaderMap::from_httparse(raw.headers)?;
@@ -237,7 +237,7 @@ impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
         Ok(match finish {
             StageResult::DoneReading { stream, result, tail } => {
                 if !tail.is_empty() {
-                    return Err(Error::Protocol("Junk after client request".into()));
+                    return Err(Error::Protocol(ProtocolErrorType::JunkAfterRequest));
                 }
 
                 let response = create_response(&result)?;
@@ -257,7 +257,7 @@ impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
                     Err(resp) => {
                         if resp.status().is_success() {
                             return Err(Error::Protocol(
-                                "Custom response must not be successful".into(),
+                                ProtocolErrorType::CustomResponseSuccessful,
                             ));
                         }
 

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -68,7 +68,7 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
     let key = request
         .headers()
         .get("Sec-WebSocket-Key")
-        .ok_or_else(|| Error::Protocol(ProtocolErrorType::MissingSecWebSocketKey))?;
+        .ok_or(Error::Protocol(ProtocolErrorType::MissingSecWebSocketKey))?;
 
     let builder = Response::builder()
         .status(StatusCode::SWITCHING_PROTOCOLS)

--- a/src/protocol/frame/coding.rs
+++ b/src/protocol/frame/coding.rs
@@ -143,7 +143,7 @@ pub enum CloseCode {
     Abnormal,
     /// Indicates that an endpoint is terminating the connection
     /// because it has received data within a message that was not
-    /// consistent with the type of the message (e.g., non-UTF-8 [RFC3629]
+    /// consistent with the type of the message (e.g., non-UTF-8 \[RFC3629\]
     /// data within a text message).
     Invalid,
     /// Indicates that an endpoint is terminating the connection

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -13,7 +13,7 @@ use super::{
     coding::{CloseCode, Control, Data, OpCode},
     mask::{apply_mask, generate_mask},
 };
-use crate::error::{Error, ProtocolErrorType, Result};
+use crate::error::{Error, ProtocolError, Result};
 
 /// A struct representing the close command.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -186,7 +186,7 @@ impl FrameHeader {
         // Disallow bad opcode
         match opcode {
             OpCode::Control(Control::Reserved(_)) | OpCode::Data(Data::Reserved(_)) => {
-                return Err(Error::Protocol(ProtocolErrorType::InvalidOpcode(first & 0x0F)))
+                return Err(Error::Protocol(ProtocolError::InvalidOpcode(first & 0x0F)))
             }
             _ => (),
         }
@@ -284,7 +284,7 @@ impl Frame {
     pub(crate) fn into_close(self) -> Result<Option<CloseFrame<'static>>> {
         match self.payload.len() {
             0 => Ok(None),
-            1 => Err(Error::Protocol(ProtocolErrorType::InvalidCloseSequence)),
+            1 => Err(Error::Protocol(ProtocolError::InvalidCloseSequence)),
             _ => {
                 let mut data = self.payload;
                 let code = NetworkEndian::read_u16(&data[0..2]).into();

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -269,9 +269,9 @@ mod tests {
     fn size_limit_hit() {
         let raw = Cursor::new(vec![0x82, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
         let mut sock = FrameSocket::new(raw);
-        match sock.read_frame(Some(5)) {
-            Err(Error::Capacity(CapacityError::MessageTooLong { size: 7, max_size: 5 })) => {}
-            _ => panic!(),
-        }
+        assert!(matches!(
+            sock.read_frame(Some(5)),
+            Err(Error::Capacity(CapacityError::MessageTooLong { size: 7, max_size: 5 }))
+        ));
     }
 }

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -8,7 +8,7 @@ mod mask;
 
 pub use self::frame::{CloseFrame, Frame, FrameHeader};
 
-use crate::error::{Error, Result};
+use crate::error::{CapacityErrorType, Error, Result};
 use input_buffer::{InputBuffer, MIN_READ};
 use log::*;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
@@ -133,9 +133,10 @@ impl FrameCodec {
                     // Enforce frame size limit early and make sure `length`
                     // is not too big (fits into `usize`).
                     if length > max_size as u64 {
-                        return Err(Error::Capacity(
-                            format!("Message length too big: {} > {}", length, max_size).into(),
-                        ));
+                        return Err(Error::Capacity(CapacityErrorType::MessageTooLong {
+                            size: length as usize,
+                            max_size,
+                        }));
                     }
 
                     let input_size = cursor.get_ref().len() as u64 - cursor.position();
@@ -155,7 +156,7 @@ impl FrameCodec {
                 .in_buffer
                 .prepare_reserve(MIN_READ)
                 .with_limit(usize::max_value())
-                .map_err(|_| Error::Capacity("Incoming TCP buffer is full".into()))?
+                .map_err(|_| Error::Capacity(CapacityErrorType::TcpBufferFull))?
                 .read_from(stream)?;
             if size == 0 {
                 trace!("no frame received");
@@ -205,6 +206,8 @@ impl FrameCodec {
 
 #[cfg(test)]
 mod tests {
+
+    use crate::error::{CapacityErrorType, Error};
 
     use super::{Frame, FrameSocket};
 
@@ -266,9 +269,9 @@ mod tests {
     fn size_limit_hit() {
         let raw = Cursor::new(vec![0x82, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
         let mut sock = FrameSocket::new(raw);
-        assert_eq!(
-            sock.read_frame(Some(5)).unwrap_err().to_string(),
-            "Space limit exceeded: Message length too big: 7 > 5"
-        );
+        match sock.read_frame(Some(5)) {
+            Err(Error::Capacity(CapacityErrorType::MessageTooLong { size: 7, max_size: 5 })) => {}
+            _ => panic!(),
+        }
     }
 }

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -8,7 +8,7 @@ mod mask;
 
 pub use self::frame::{CloseFrame, Frame, FrameHeader};
 
-use crate::error::{CapacityErrorType, Error, Result};
+use crate::error::{CapacityError, Error, Result};
 use input_buffer::{InputBuffer, MIN_READ};
 use log::*;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
@@ -133,7 +133,7 @@ impl FrameCodec {
                     // Enforce frame size limit early and make sure `length`
                     // is not too big (fits into `usize`).
                     if length > max_size as u64 {
-                        return Err(Error::Capacity(CapacityErrorType::MessageTooLong {
+                        return Err(Error::Capacity(CapacityError::MessageTooLong {
                             size: length as usize,
                             max_size,
                         }));
@@ -156,7 +156,7 @@ impl FrameCodec {
                 .in_buffer
                 .prepare_reserve(MIN_READ)
                 .with_limit(usize::max_value())
-                .map_err(|_| Error::Capacity(CapacityErrorType::TcpBufferFull))?
+                .map_err(|_| Error::Capacity(CapacityError::TcpBufferFull))?
                 .read_from(stream)?;
             if size == 0 {
                 trace!("no frame received");
@@ -207,7 +207,7 @@ impl FrameCodec {
 #[cfg(test)]
 mod tests {
 
-    use crate::error::{CapacityErrorType, Error};
+    use crate::error::{CapacityError, Error};
 
     use super::{Frame, FrameSocket};
 
@@ -270,7 +270,7 @@ mod tests {
         let raw = Cursor::new(vec![0x82, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
         let mut sock = FrameSocket::new(raw);
         match sock.read_frame(Some(5)) {
-            Err(Error::Capacity(CapacityErrorType::MessageTooLong { size: 7, max_size: 5 })) => {}
+            Err(Error::Capacity(CapacityError::MessageTooLong { size: 7, max_size: 5 })) => {}
             _ => panic!(),
         }
     }

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use super::frame::CloseFrame;
-use crate::error::{CapacityErrorType, Error, Result};
+use crate::error::{CapacityError, Error, Result};
 
 mod string_collect {
     use utf8::DecodeError;
@@ -122,7 +122,7 @@ impl IncompleteMessage {
         let portion_size = tail.as_ref().len();
         // Be careful about integer overflows here.
         if my_size > max_size || portion_size > max_size - my_size {
-            return Err(Error::Capacity(CapacityErrorType::MessageTooLong {
+            return Err(Error::Capacity(CapacityError::MessageTooLong {
                 size: my_size + portion_size,
                 max_size,
             }));

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use super::frame::CloseFrame;
-use crate::error::{Error, Result};
+use crate::error::{CapacityErrorType, Error, Result};
 
 mod string_collect {
     use utf8::DecodeError;
@@ -122,9 +122,10 @@ impl IncompleteMessage {
         let portion_size = tail.as_ref().len();
         // Be careful about integer overflows here.
         if my_size > max_size || portion_size > max_size - my_size {
-            return Err(Error::Capacity(
-                format!("Message too big: {} + {} > {}", my_size, portion_size, max_size).into(),
-            ));
+            return Err(Error::Capacity(CapacityErrorType::MessageTooLong {
+                size: my_size + portion_size,
+                max_size,
+            }));
         }
 
         match self.collector {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -713,10 +713,10 @@ mod tests {
         let limit = WebSocketConfig { max_message_size: Some(10), ..WebSocketConfig::default() };
         let mut socket = WebSocket::from_raw_socket(WriteMoc(incoming), Role::Client, Some(limit));
 
-        match socket.read_message() {
-            Err(Error::Capacity(CapacityError::MessageTooLong { size: 13, max_size: 10 })) => {}
-            _ => panic!(),
-        }
+        assert!(matches!(
+            socket.read_message(),
+            Err(Error::Capacity(CapacityError::MessageTooLong { size: 13, max_size: 10 }))
+        ));
     }
 
     #[test]
@@ -725,9 +725,9 @@ mod tests {
         let limit = WebSocketConfig { max_message_size: Some(2), ..WebSocketConfig::default() };
         let mut socket = WebSocket::from_raw_socket(WriteMoc(incoming), Role::Client, Some(limit));
 
-        match socket.read_message() {
-            Err(Error::Capacity(CapacityError::MessageTooLong { size: 3, max_size: 2 })) => {}
-            _ => panic!(),
-        }
+        assert!(matches!(
+            socket.read_message(),
+            Err(Error::Capacity(CapacityError::MessageTooLong { size: 3, max_size: 2 }))
+        ));
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -669,7 +669,7 @@ impl<T> CheckConnectionReset for Result<T> {
 #[cfg(test)]
 mod tests {
     use super::{Message, Role, WebSocket, WebSocketConfig};
-    use crate::error::{CapacityErrorType, Error};
+    use crate::error::{CapacityError, Error};
 
     use std::{io, io::Cursor};
 
@@ -714,7 +714,7 @@ mod tests {
         let mut socket = WebSocket::from_raw_socket(WriteMoc(incoming), Role::Client, Some(limit));
 
         match socket.read_message() {
-            Err(Error::Capacity(CapacityErrorType::MessageTooLong { size: 13, max_size: 10 })) => {}
+            Err(Error::Capacity(CapacityError::MessageTooLong { size: 13, max_size: 10 })) => {}
             _ => panic!(),
         }
     }
@@ -726,7 +726,7 @@ mod tests {
         let mut socket = WebSocket::from_raw_socket(WriteMoc(incoming), Role::Client, Some(limit));
 
         match socket.read_message() {
-            Err(Error::Capacity(CapacityErrorType::MessageTooLong { size: 3, max_size: 2 })) => {}
+            Err(Error::Capacity(CapacityError::MessageTooLong { size: 3, max_size: 2 })) => {}
             _ => panic!(),
         }
     }

--- a/tests/no_send_after_close.rs
+++ b/tests/no_send_after_close.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use tungstenite::{accept, connect, error::ProtocolErrorType, Error, Message};
+use tungstenite::{accept, connect, error::ProtocolError, Error, Message};
 use url::Url;
 
 #[test]
@@ -46,7 +46,7 @@ fn test_no_send_after_close() {
     assert!(err.is_err());
 
     match err.unwrap_err() {
-        Error::Protocol(s) => assert_eq!(s, ProtocolErrorType::SendAfterClosing),
+        Error::Protocol(s) => assert_eq!(s, ProtocolError::SendAfterClosing),
         e => panic!("unexpected error: {:?}", e),
     }
 

--- a/tests/no_send_after_close.rs
+++ b/tests/no_send_after_close.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use tungstenite::{accept, connect, Error, Message};
+use tungstenite::{accept, connect, error::ProtocolErrorType, Error, Message};
 use url::Url;
 
 #[test]
@@ -46,7 +46,7 @@ fn test_no_send_after_close() {
     assert!(err.is_err());
 
     match err.unwrap_err() {
-        Error::Protocol(s) => assert_eq!("Sending after closing is not allowed", s),
+        Error::Protocol(s) => assert_eq!(s, ProtocolErrorType::SendAfterClosing),
         e => panic!("unexpected error: {:?}", e),
     }
 


### PR DESCRIPTION
The current tungstenite error system doesn't allow for easily matching specific protocol, URL, and capacity errors due to use of string messages to distinguish different error subtypes. As such, I've created distinct enums for the different protocol, URL, and capacity errors that may occur.

To give an example of how this would be useful, imagine a scenario where one wants to check if an operation failed due to the remote host closing the connection without performing the closing handshake. Currently, one may write `Err(Error::Protocol(vioation)) if vioation.contains("closing handshake") => { ... }` or similar. With my new change, they now may write `Err(Error::Protocol(ProtocolErrorType::ResetWithoutClosingHandshake)) => { ... }` instead. This is both more efficient as it avoids comparing strings while also allowing the error message to be changed without breaking existing pattern matching.