### PR TITLE
Update input_buffer to use the official version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1.3.2"
 bytes = "1.0"
 http = "0.2"
 httparse = "1.3.4"
-input_buffer = { version = "0.4.0", git = "https://github.com/snapview/input_buffer.git" }
+input_buffer = "0.4.0"
 log = "0.4.8"
 rand = "0.8.0"
 sha-1 = "0.9"


### PR DESCRIPTION
`input_buffer` 0.4.0 was released today. This changes from a direct git dependency to the official version.