### PR TITLE
allow sending messages with static or shared data

### DIFF
--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -1,0 +1,149 @@
+use bytes::Bytes;
+
+/// Binary message data
+#[derive(Debug, Clone)]
+pub struct MessageData(MessageDataImpl);
+
+/// opaque inner type to allow modifying the implementation in the future
+#[derive(Debug, Clone)]
+enum MessageDataImpl {
+    Shared(Bytes),
+    Unique(Vec<u8>),
+}
+
+impl MessageData {
+    pub fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    fn make_unique(&mut self) {
+        if let MessageDataImpl::Shared(data) = &self.0 {
+            self.0 = MessageDataImpl::Unique(Vec::from(data.as_ref()));
+        }
+    }
+}
+
+impl PartialEq for MessageData {
+    fn eq(&self, other: &MessageData) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl Eq for MessageData {}
+
+impl From<MessageData> for Vec<u8> {
+    fn from(data: MessageData) -> Vec<u8> {
+        match data.0 {
+            MessageDataImpl::Shared(data) => {
+                let mut bytes = Vec::with_capacity(data.len());
+                bytes.copy_from_slice(data.as_ref());
+                bytes
+            }
+            MessageDataImpl::Unique(data) => data,
+        }
+    }
+}
+
+impl From<MessageData> for Bytes {
+    fn from(data: MessageData) -> Bytes {
+        match data.0 {
+            MessageDataImpl::Shared(data) => data,
+            MessageDataImpl::Unique(data) => data.into(),
+        }
+    }
+}
+
+impl AsRef<[u8]> for MessageData {
+    fn as_ref(&self) -> &[u8] {
+        match &self.0 {
+            MessageDataImpl::Shared(data) => data.as_ref(),
+            MessageDataImpl::Unique(data) => data.as_ref(),
+        }
+    }
+}
+
+impl AsMut<[u8]> for MessageData {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.make_unique();
+        match &mut self.0 {
+            MessageDataImpl::Unique(data) => data.as_mut_slice(),
+            MessageDataImpl::Shared(_) => unreachable!("Data has just been made unique"),
+        }
+    }
+}
+
+/// String message data
+#[derive(Debug, Clone)]
+pub struct MessageStringData(MessageStringDataImpl);
+
+/// opaque inner type to allow modifying the implementation in the future
+#[derive(Debug, Clone)]
+enum MessageStringDataImpl {
+    Static(&'static str),
+    Unique(String),
+}
+
+impl PartialEq for MessageStringData {
+    fn eq(&self, other: &MessageStringData) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl Eq for MessageStringData {}
+
+impl From<MessageStringData> for String {
+    fn from(data: MessageStringData) -> String {
+        match data.0 {
+            MessageStringDataImpl::Static(data) => data.into(),
+            MessageStringDataImpl::Unique(data) => data,
+        }
+    }
+}
+
+impl From<MessageStringData> for MessageData {
+    fn from(data: MessageStringData) -> MessageData {
+        match data.0 {
+            MessageStringDataImpl::Static(data) => MessageData::from(data.as_bytes()),
+            MessageStringDataImpl::Unique(data) => MessageData::from(data.into_bytes()),
+        }
+    }
+}
+
+impl AsRef<str> for MessageStringData {
+    fn as_ref(&self) -> &str {
+        match &self.0 {
+            MessageStringDataImpl::Static(data) => *data,
+            MessageStringDataImpl::Unique(data) => data.as_ref(),
+        }
+    }
+}
+
+impl From<String> for MessageStringData {
+    fn from(string: String) -> MessageStringData {
+        MessageStringData(MessageStringDataImpl::Unique(string))
+    }
+}
+
+impl From<&'static str> for MessageStringData {
+    fn from(string: &'static str) -> MessageStringData {
+        MessageStringData(MessageStringDataImpl::Static(string))
+    }
+}
+
+impl From<Vec<u8>> for MessageData {
+    fn from(data: Vec<u8>) -> MessageData {
+        MessageData(MessageDataImpl::Unique(data))
+    }
+}
+
+impl From<&'static [u8]> for MessageData {
+    fn from(data: &'static [u8]) -> MessageData {
+        MessageData(MessageDataImpl::Shared(Bytes::from_static(data)))
+    }
+}
+
+impl From<Bytes> for MessageData {
+    fn from(data: Bytes) -> MessageData {
+        MessageData(MessageDataImpl::Shared(data))
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod frame;
 
+mod data;
 mod message;
 
 pub use self::{frame::CloseFrame, message::Message};
@@ -24,7 +25,6 @@ use crate::{
     error::{Error, ProtocolError, Result},
     util::NonBlockingResult,
 };
-use std::borrow::Cow;
 
 /// Indicates a Client or Server role of the websocket
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -349,12 +349,7 @@ impl WebSocketContext {
         }
 
         let frame = match message {
-            Message::Text(Cow::Owned(data)) => {
-                Frame::message(data.into_bytes(), OpCode::Data(OpData::Text), true)
-            }
-            Message::Text(Cow::Borrowed(data)) => {
-                Frame::message(data.as_bytes(), OpCode::Data(OpData::Text), true)
-            }
+            Message::Text(data) => Frame::message(data, OpCode::Data(OpData::Text), true),
             Message::Binary(data) => Frame::message(data, OpCode::Data(OpData::Binary), true),
             Message::Ping(data) => Frame::ping(data),
             Message::Pong(data) => {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -426,7 +426,7 @@ impl WebSocketContext {
     where
         Stream: Read + Write,
     {
-        if let Some(mut frame) = self
+        if let Some(frame) = self
             .frame
             .read_frame(stream, self.config.max_frame_size)
             .check_connection_reset(self.state)?
@@ -448,11 +448,7 @@ impl WebSocketContext {
 
             match self.role {
                 Role::Server => {
-                    if frame.is_masked() {
-                        // A server MUST remove masking for data frames received from a client
-                        // as described in Section 5.3. (RFC 6455)
-                        frame.apply_mask()
-                    } else if !self.config.accept_unmasked_frames {
+                    if !frame.is_masked() && !self.config.accept_unmasked_frames {
                         // The server MUST close the connection upon receiving a
                         // frame that is not masked. (RFC 6455)
                         // The only exception here is if the user explicitly accepts given


### PR DESCRIPTION
This allows the server to skip allocating buffers holding the message data to be send if the data is static.

- This doesn't really save anything for clients atm due to the need of masking, although changing the masking logic to run on the output buffer instead of the message buffer could solve that.
- The change in the `Message` fields data make this a breaking change for any code directly creating or deconstructing the `Message` enum.
- Keeping the `text` and `binary` methods intact requires adding separate `static_*` methods, an alternative might be to change `text`/`binary` to take an `Into<Cow<_>>` directly, this would break any code calling those methods with anything that doesn't implement `Into<Cow<_>>` but should be fine for the most common parameters of `String/&str/Vec<u8>/&[u8]`