### PR TITLE
downgrade webpki, use rustls-native-certs instead of webpki-roots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 default = []
 native-tls = ["native-tls-crate"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
-rustls-tls = ["rustls", "webpki", "webpki-roots"]
+rustls-tls = ["rustls", "webpki", "rustls-native-certs"]
 
 [dependencies]
 base64 = "0.13.0"
@@ -46,11 +46,11 @@ version = "0.19.0"
 
 [dependencies.webpki]
 optional = true
-version = "0.22.0"
+version = "0.21"
 
-[dependencies.webpki-roots]
+[dependencies.rustls-native-certs]
 optional = true
-version = "0.22.0"
+version = "0.5.0"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -72,7 +72,10 @@ mod encryption {
             Mode::Tls => {
                 let config = {
                     let mut config = ClientConfig::new();
-                    config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+                    config.root_store = match rustls_native_certs::load_native_certs() {
+                        Ok(store) => store,
+                        Err((_, err)) => Err(err)?,
+                    };
 
                     Arc::new(config)
                 };

--- a/src/client.rs
+++ b/src/client.rs
@@ -72,10 +72,7 @@ mod encryption {
             Mode::Tls => {
                 let config = {
                     let mut config = ClientConfig::new();
-                    config.root_store = match rustls_native_certs::load_native_certs() {
-                        Ok(store) => store,
-                        Err((_, err)) => Err(err)?,
-                    };
+                    config.root_store = rustls_native_certs::load_native_certs().map_err(|(_, err)| err)?;
 
                     Arc::new(config)
                 };


### PR DESCRIPTION
rustls 0.19 still uses webpki 0.21, and webpki 0.22 contains breaking changes so webpki must be downgraded. This PR also changes it so that rustls-native-certs is used instead of webpki-roots (related #203).