### PR TITLE
optionally disable verbose logging to improve performance

### DIFF
--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -1,5 +1,4 @@
 use bytes::Buf;
-use log::*;
 use std::io::{Cursor, Read, Write};
 
 use crate::{

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -1,5 +1,4 @@
 use byteorder::{ByteOrder, NetworkEndian, ReadBytesExt, WriteBytesExt};
-use log::*;
 use std::{
     borrow::Cow,
     default::Default,

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -8,8 +8,6 @@ mod mask;
 
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 
-use log::*;
-
 pub use self::frame::{CloseFrame, Frame, FrameHeader};
 use crate::{
     error::{CapacityError, Error, Result},


### PR DESCRIPTION
Currently the logging is too verbose. As seen from the flamegraph, half of the time is spent on logging. This PR adds a feature `no-verbose-logging` that disables these annoying loggings.
![image](https://user-images.githubusercontent.com/33482468/123521022-9c6ad000-d6e6-11eb-8760-28f38acf67b3.png)
