### PR TITLE
Faster implementation of `InputBuffer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ byteorder = "1.3.2"
 bytes = "1.0"
 http = "0.2"
 httparse = "1.3.4"
-input_buffer = "0.4.0"
 log = "0.4.8"
 rand = "0.8.0"
 sha-1 = "0.9"
@@ -53,5 +52,6 @@ optional = true
 version = "0.5.0"
 
 [dev-dependencies]
+input_buffer = "0.5.0"
 env_logger = "0.8.1"
 net2 = "0.2.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,12 @@ optional = true
 version = "0.5.0"
 
 [dev-dependencies]
-input_buffer = "0.5.0"
+criterion = "0.3.4"
 env_logger = "0.8.1"
+input_buffer = "0.5.0"
 net2 = "0.2.33"
+rand = "0.8.4"
+
+[[bench]]
+name = "buffer"
+harness = false

--- a/benches/buffer.rs
+++ b/benches/buffer.rs
@@ -1,0 +1,36 @@
+use std::io::{Cursor, Read};
+
+use criterion::*;
+use input_buffer::InputBuffer;
+use tungstenite::buffer::ReadBuffer;
+
+const CHUNK_SIZE: usize = 4096;
+
+#[inline]
+fn current_input_buffer(mut stream: impl Read) {
+    let mut buffer = InputBuffer::with_capacity(CHUNK_SIZE);
+    while buffer.read_from(&mut stream).unwrap() != 0 {}
+}
+
+#[inline]
+fn fast_input_buffer(mut stream: impl Read) {
+    let mut buffer = ReadBuffer::<CHUNK_SIZE>::new();
+    while buffer.read_from(&mut stream).unwrap() != 0 {}
+}
+
+fn benchmark(c: &mut Criterion) {
+    const STREAM_SIZE: usize = 1024 * 1024 * 4;
+    let data: Vec<u8> = (0..STREAM_SIZE).map(|_| rand::random()).collect();
+    let stream = Cursor::new(data);
+
+    let mut group = c.benchmark_group("buffers");
+    group.throughput(Throughput::Bytes(STREAM_SIZE as u64));
+    group.bench_function("InputBuffer", |b| {
+        b.iter(|| current_input_buffer(black_box(stream.clone())))
+    });
+    group.bench_function("ReadBuffer", |b| b.iter(|| fast_input_buffer(black_box(stream.clone()))));
+    group.finish();
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,111 @@
+//! A buffer for reading data from the network.
+//!
+//! The `ReadBuffer` is a buffer of bytes similar to a first-in, first-out queue.
+//! It is filled by reading from a stream supporting `Read` and is then
+//! accessible as a cursor for reading bytes.
+
+use std::io::{Cursor, Read, Result as IoResult};
+
+use bytes::Buf;
+
+/// A FIFO buffer for reading packets from the network.
+#[derive(Debug)]
+pub struct ReadBuffer<const CHUNK_SIZE: usize> {
+    storage: Cursor<Vec<u8>>,
+    chunk: [u8; CHUNK_SIZE],
+}
+
+impl<const CHUNK_SIZE: usize> ReadBuffer<CHUNK_SIZE> {
+    /// Create a new empty input buffer.
+    pub fn new() -> Self {
+        Self::with_capacity(CHUNK_SIZE)
+    }
+
+    /// Create a new empty input buffer with a given `capacity`.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::from_partially_read(Vec::with_capacity(capacity))
+    }
+
+    /// Create a input buffer filled with previously read data.
+    pub fn from_partially_read(part: Vec<u8>) -> Self {
+        Self { storage: Cursor::new(part), chunk: [0; CHUNK_SIZE] }
+    }
+
+    /// Get a cursor to the data storage.
+    pub fn as_cursor(&self) -> &Cursor<Vec<u8>> {
+        &self.storage
+    }
+
+    /// Get a cursor to the mutable data storage.
+    pub fn as_cursor_mut(&mut self) -> &mut Cursor<Vec<u8>> {
+        &mut self.storage
+    }
+
+    /// Consume the `ReadBuffer` and get the internal storage.
+    pub fn into_vec(mut self) -> Vec<u8> {
+        // Current implementation of `tungstenite-rs` expects that the `into_vec()` drains
+        // the data from the container that has already been read by the cursor.
+        let pos = self.storage.position() as usize;
+        self.storage.get_mut().drain(0..pos).count();
+        self.storage.set_position(0);
+
+        // Now we can safely return the internal container.
+        self.storage.into_inner()
+    }
+
+    /// Read next portion of data from the given input stream.
+    pub fn read_from<S: Read>(&mut self, stream: &mut S) -> IoResult<usize> {
+        let size = stream.read(&mut self.chunk)?;
+        self.storage.get_mut().extend_from_slice(&self.chunk[..size]);
+        Ok(size)
+    }
+}
+
+impl<const CHUNK_SIZE: usize> Buf for ReadBuffer<CHUNK_SIZE> {
+    fn remaining(&self) -> usize {
+        Buf::remaining(self.as_cursor())
+    }
+
+    fn chunk(&self) -> &[u8] {
+        Buf::chunk(self.as_cursor())
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        Buf::advance(self.as_cursor_mut(), cnt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_reading() {
+        let mut input = Cursor::new(b"Hello World!".to_vec());
+        let mut buffer = ReadBuffer::<4096>::new();
+        let size = buffer.read_from(&mut input).unwrap();
+        assert_eq!(size, 12);
+        assert_eq!(buffer.chunk(), b"Hello World!");
+    }
+
+    #[test]
+    fn reading_in_chunks() {
+        let mut inp = Cursor::new(b"Hello World!".to_vec());
+        let mut buf = ReadBuffer::<4>::new();
+
+        let size = buf.read_from(&mut inp).unwrap();
+        assert_eq!(size, 4);
+        assert_eq!(buf.chunk(), b"Hell");
+
+        buf.advance(2);
+        assert_eq!(buf.chunk(), b"ll");
+
+        let size = buf.read_from(&mut inp).unwrap();
+        assert_eq!(size, 4);
+        assert_eq!(buf.chunk(), b"llo Wo");
+
+        let size = buf.read_from(&mut inp).unwrap();
+        assert_eq!(size, 4);
+        assert_eq!(buf.chunk(), b"llo World!");
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -72,7 +72,8 @@ mod encryption {
             Mode::Tls => {
                 let config = {
                     let mut config = ClientConfig::new();
-                    config.root_store = rustls_native_certs::load_native_certs().map_err(|(_, err)| err)?;
+                    config.root_store =
+                        rustls_native_certs::load_native_certs().map_err(|(_, err)| err)?;
 
                     Arc::new(config)
                 };

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,8 +127,6 @@ pub enum CapacityError {
     #[error("Too many headers")]
     TooManyHeaders,
     /// Received header is too long.
-    #[error("Header too long")]
-    HeaderTooLong,
     /// Message is bigger than the maximum allowed size.
     #[error("Message too long: {size} > {max_size}")]
     MessageTooLong {
@@ -137,9 +135,6 @@ pub enum CapacityError {
         /// The maximum allowed message size.
         max_size: usize,
     },
-    /// TCP buffer is full.
-    #[error("Incoming TCP buffer is full")]
-    TcpBufferFull,
 }
 
 /// Indicates the specific type/cause of a protocol error.

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -131,9 +131,6 @@ mod tests {
     #[test]
     fn key_conversion() {
         // example from RFC 6455
-        assert_eq!(
-            derive_accept_key(b"dGhlIHNhbXBsZSBub25jZQ=="),
-            "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
-        );
+        assert_eq!(derive_accept_key(b"dGhlIHNhbXBsZSBub25jZQ=="), "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 
 pub use http;
 
-mod buffer;
+pub mod buffer;
 pub mod client;
 pub mod error;
 pub mod handshake;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub use http;
 
+mod buffer;
 pub mod client;
 pub mod error;
 pub mod handshake;
@@ -21,6 +22,9 @@ pub mod protocol;
 pub mod server;
 pub mod stream;
 pub mod util;
+
+const READ_BUFFER_CHUNK_SIZE: usize = 4096;
+type ReadBuffer = buffer::ReadBuffer<READ_BUFFER_CHUNK_SIZE>;
 
 pub use crate::{
     client::{client, connect},


### PR DESCRIPTION
Fixes https://github.com/snapview/tungstenite-rs/issues/210.

Please [check the discussion and decision](https://github.com/snapview/input_buffer/issues/6#issuecomment-870548303) if you don't know the context as well as the [latest PR in `input_buffer`](https://github.com/snapview/input_buffer/pull/9).

It seems like the new simplified implementation has only significant difference on x86_64 architecture while the changes on Armv8.4-A A64 (Apple M1) are not that significant as both versions perform really well. On ARM the new version even behaves a bit slower (but not significantly slower), however the difference on Intel (x86_64) architecture is quite significant.

```
===== M1 Mac (Armv8.4-A A64) =====

buffers/InputBuffer     time:   [543.66 us 549.32 us 555.54 us]
                        thrpt:  [7.0315 GiB/s 7.1110 GiB/s 7.1851 GiB/s]

buffers/ReadBuffer      time:   [552.16 us 565.83 us 581.26 us]
                        thrpt:  [6.7203 GiB/s 6.9036 GiB/s 7.0745 GiB/s]


===== Intel (x86_64) =====

buffers/InputBuffer     time:   [4.7392 ms 4.7601 ms 4.7817 ms]
                        thrpt:  [836.52 MiB/s 840.31 MiB/s 844.03 MiB/s]

buffers/ReadBuffer      time:   [726.86 us 730.72 us 734.81 us]
                        thrpt:  [5.3160 GiB/s 5.3457 GiB/s 5.3741 GiB/s]
```

So it seems like migrating to the newer `ReadBuffer` makes sense as the 'average performance gain' is quite significant (and I believe most users are still using x86_64).

⚠️ Notes:
1. The PR also removes a couple of errors that could have been triggered by `tungstenite-rs`. These were removed as they could only occur if the incoming message does not fit into the hardcoded `u32::max_value()`. Currently we have [`max_frame_size` and `max_message_size`](https://docs.rs/tungstenite/0.13.0/tungstenite/protocol/struct.WebSocketConfig.html), but we don't use them to cap the size of the input/read buffer (instead we compare the values once we read something). This in theory is not a problem when using `tungstenite-rs` with non-blocking sockets (like in case of `tokio-tungstenite`), though it could pose the issue for those ones who use blocking sockets. In other words, the previous reading with `u32::max_value()` did not really add any sort of "additional protection", so I removed them all together to not complicate the `ReadBuffer` implementation.
2. There is no automation to run `criterion` benchmarks with our CI. That's fine as `criterion` is not meant to be used like this and may give many false positives and false negatives when used like this. In order to automate benchmarking with CI we have to use a tool like [lai](https://github.com/bheisler/iai) that was written to be used for such purposes (it works differently than `criterion`), but I think it's better to make it as part of a separate PR.


P.S.: Thanks @qiujiangkun for bringing this topic and performance testing of `tungstenite-rs` 👍 