### PR TITLE
Enable root cert providers through feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.15.0 (unreleased)
+
+- Allow selecting the method of loading root certificates if `rustls` is used as TLS implementation.
+  - Two new feature flags `rustls-tls-native-roots` and `rustls-tls-webpki-roots` have been added
+    that activate the respective method to load certificates.
+  - The `rustls-tls` flag was removed to raise awareness of this change. Otherwise, compilation
+    would have continue to work and potential errors (due to different or missing certificates)
+    only occurred at runtime.
+  - The new feature flags are additive. If both are enabled, both methods will be used to add
+    certificates to the TLS configuration.
+
 # 0.14.0
 
 - Use `rustls-native-certs` instead of `webpki-root` when `rustls-tls` feature is enabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,8 @@ all-features = true
 default = []
 native-tls = ["native-tls-crate"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
-rustls-tls = ["rustls", "webpki"]
-rustls-tls-native-roots = ["rustls-tls", "rustls-native-certs"]
-rustls-tls-webpki-roots = ["rustls-tls", "webpki-roots"]
+rustls-tls-native-roots = ["rustls", "webpki", "rustls-native-certs"]
+rustls-tls-webpki-roots = ["rustls", "webpki", "webpki-roots"]
 
 [dependencies]
 base64 = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ all-features = true
 default = []
 native-tls = ["native-tls-crate"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
-rustls-tls = ["rustls", "webpki", "rustls-native-certs"]
+rustls-tls = ["rustls", "webpki"]
+rustls-tls-native-roots = ["rustls-tls", "rustls-native-certs"]
+rustls-tls-webpki-roots = ["rustls-tls", "webpki-roots"]
 
 [dependencies]
 base64 = "0.13.0"
@@ -43,13 +45,17 @@ version = "0.2.3"
 optional = true
 version = "0.19.0"
 
+[dependencies.rustls-native-certs]
+optional = true
+version = "0.5.0"
+
 [dependencies.webpki]
 optional = true
 version = "0.21"
 
-[dependencies.rustls-native-certs]
+[dependencies.webpki-roots]
 optional = true
-version = "0.5.0"
+version = "0.21"
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -50,7 +50,10 @@ mod encryption {
     }
 }
 
-#[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
+#[cfg(all(
+    any(feature = "rustls-tls-native-roots", feature = "rustls-tls-webpki-roots"),
+    not(feature = "native-tls")
+))]
 mod encryption {
     use rustls::ClientConfig;
     pub use rustls::{ClientSession, StreamOwned};
@@ -96,7 +99,11 @@ mod encryption {
     }
 }
 
-#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+#[cfg(not(any(
+    feature = "native-tls",
+    feature = "rustls-tls-native-roots",
+    feature = "rustls-tls-webpki-roots"
+)))]
 mod encryption {
     use std::net::TcpStream;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -76,12 +76,12 @@ mod encryption {
                 let config = {
                     #[allow(unused_mut)]
                     let mut config = ClientConfig::new();
-                    #[cfg(feature = "rustls-native-roots")]
+                    #[cfg(feature = "rustls-tls-native-roots")]
                     {
                         config.root_store =
                             rustls_native_certs::load_native_certs().map_err(|(_, err)| err)?;
                     }
-                    #[cfg(feature = "rustls-webpki-roots")]
+                    #[cfg(feature = "rustls-tls-webpki-roots")]
                     {
                         config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
                     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -253,11 +253,11 @@ pub enum TlsError {
     #[error("native-tls error: {0}")]
     Native(#[from] native_tls_crate::Error),
     /// Rustls error.
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(any(feature = "rustls-tls-native-roots", feature = "rustls-tls-webpki-roots"))]
     #[error("rustls error: {0}")]
     Rustls(#[from] rustls::TLSError),
     /// DNS name resolution error.
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(any(feature = "rustls-tls-native-roots", feature = "rustls-tls-webpki-roots"))]
     #[error("Invalid DNS name: {0}")]
     Dns(#[from] webpki::InvalidDNSNameError),
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -10,7 +10,7 @@ use std::net::TcpStream;
 
 #[cfg(feature = "native-tls")]
 use native_tls_crate::TlsStream;
-#[cfg(feature = "rustls-tls")]
+#[cfg(any(feature = "rustls-tls-native-roots", feature = "rustls-tls-webpki-roots"))]
 use rustls::StreamOwned;
 
 /// Stream mode, either plain TCP or TLS.
@@ -41,7 +41,7 @@ impl<S: Read + Write + NoDelay> NoDelay for TlsStream<S> {
     }
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(any(feature = "rustls-tls-native-roots", feature = "rustls-tls-webpki-roots"))]
 impl<S: rustls::Session, T: Read + Write + NoDelay> NoDelay for StreamOwned<S, T> {
     fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
         self.sock.set_nodelay(nodelay)

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -1,6 +1,10 @@
 //! Verifies that the server returns a `ConnectionClosed` error when the connection
 //! is closed from the server's point of view and drop the underlying tcp socket.
-#![cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+#![cfg(any(
+    feature = "native-tls",
+    feature = "rustls-tls-native-roots",
+    feature = "rustls-tls-webpki-roots"
+))]
 
 use std::{
     net::{TcpListener, TcpStream},
@@ -15,7 +19,10 @@ use url::Url;
 
 #[cfg(feature = "native-tls")]
 type Sock = WebSocket<Stream<TcpStream, native_tls_crate::TlsStream<TcpStream>>>;
-#[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
+#[cfg(all(
+    any(feature = "rustls-tls-native-roots", feature = "rustls-tls-webpki-roots"),
+    not(feature = "native-tls")
+))]
 type Sock = WebSocket<Stream<TcpStream, rustls::StreamOwned<rustls::ClientSession, TcpStream>>>;
 
 fn do_test<CT, ST>(port: u16, client_task: CT, server_task: ST)


### PR DESCRIPTION
Add feature flags for different providers of root certificates as discussed in #215. As mentioned in the issue `rustls` still uses the `0.21` version of `webpki`, that's why the `0.22` version wasn't used here. There's already a `0.20.0-beta2` of `rustls` so after some waiting that issue might be solved with an upgrade of rustls. As that new version brings many breaking changes, I didn't upgrade to the beta version for now.

## Currently open questions

- [x] This change will break implementations for most users as this will not change the API but with only the `rustls-tls` feature enabled there will be no root certs available at runtime. Show we maybe make the new `rustls-tls-*` flags independent of the `rustls-tls` flag and turn `rustls-tls` into an alias for `rustls-tls-native-roots`?
- [x] I believe the `Mode` enum could be an interesting choice to allow for custom certs to be passed in as optional values. That would mean to turn `Mode::Tls` into something like `Mode::Tls { root_certs: Option<TLSServerTrustAnchors> }`, but this must be further investigated to make it compatible for situations where `native-tls` is used instead. Any thoughts?
- [x] The current implementation allows for both new feature flags to be present and results in both native certs as well as embedded certs to be loaded. This should be the preferred way to make everyone happy I hope?
  - [x] Have to test how the native roots behave when there are none available (currently hoping that it won't fail and just returns an empty root store).
