### PR TITLE
Fix clippy warnings and deprecated settings

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,4 +4,4 @@
 # Break complex but short statements a bit less.
 use_small_heuristics = "Max"
 
-merge_imports = true
+imports_granularity = "Crate"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -81,6 +81,12 @@ impl<const CHUNK_SIZE: usize> Buf for ReadBuffer<CHUNK_SIZE> {
     }
 }
 
+impl<const CHUNK_SIZE: usize> Default for ReadBuffer<CHUNK_SIZE> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/protocol/frame/coding.rs
+++ b/src/protocol/frame/coding.rs
@@ -71,14 +71,14 @@ impl fmt::Display for OpCode {
     }
 }
 
-impl Into<u8> for OpCode {
-    fn into(self) -> u8 {
+impl From<OpCode> for u8 {
+    fn from(code: OpCode) -> Self {
         use self::{
             Control::{Close, Ping, Pong},
             Data::{Binary, Continue, Text},
             OpCode::*,
         };
-        match self {
+        match code {
             Data(Continue) => 0,
             Data(Text) => 1,
             Data(Binary) => 2,

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -84,6 +84,7 @@ impl FrameHeader {
     }
 
     /// Get the size of the header formatted with given payload length.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self, length: u64) -> usize {
         2 + LengthFormat::for_length(length).extra_bytes() + if self.mask.is_some() { 4 } else { 0 }
     }

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -1,5 +1,5 @@
 use std::{
-    convert::{AsRef, From, Into},
+    convert::{AsRef, From, Into, TryFrom},
     fmt,
     result::Result as StdResult,
     str,
@@ -270,32 +270,40 @@ impl Message {
 }
 
 impl From<String> for Message {
-    fn from(string: String) -> Message {
+    fn from(string: String) -> Self {
         Message::text(string)
     }
 }
 
 impl<'s> From<&'s str> for Message {
-    fn from(string: &'s str) -> Message {
+    fn from(string: &'s str) -> Self {
         Message::text(string)
     }
 }
 
 impl<'b> From<&'b [u8]> for Message {
-    fn from(data: &'b [u8]) -> Message {
+    fn from(data: &'b [u8]) -> Self {
         Message::binary(data)
     }
 }
 
 impl From<Vec<u8>> for Message {
-    fn from(data: Vec<u8>) -> Message {
+    fn from(data: Vec<u8>) -> Self {
         Message::binary(data)
     }
 }
 
-impl Into<Vec<u8>> for Message {
-    fn into(self) -> Vec<u8> {
-        self.into_data()
+impl From<Message> for Vec<u8> {
+    fn from(message: Message) -> Self {
+        message.into_data()
+    }
+}
+
+impl TryFrom<Message> for String {
+    type Error = Error;
+
+    fn try_from(value: Message) -> StdResult<Self, Self::Error> {
+        value.into_text()
     }
 }
 


### PR DESCRIPTION
This fixes warnings by lates clippy and replaces deprecated settings from `rustfmt`.
Also, I added a `TryFrom` implementation for `Message -> String` as that seemed the only one missing in the list of conversion implementations for `Message`.