### PR TITLE
Reduce crate package size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/tungstenite/0.14.0"
 repository = "https://github.com/snapview/tungstenite-rs"
 version = "0.14.0"
 edition = "2018"
+include = ["benches/**/*", "src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Reduce the crate package size (the file that is uploaded to the creates.io registry) by only including necessary files. This allows faster downloads for everyone.

The include filters were generated with `cargo-diet` and then further adjusted until `cargo package` worked.﻿