### PR TITLE
Switch from `.unwrap()` to `match`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,20 @@ use std::thread::spawn;
 use tungstenite::accept;
 
 /// A WebSocket echo server
-fn main () {
+fn main() {
     let server = TcpListener::bind("127.0.0.1:9001").unwrap();
     for stream in server.incoming() {
-        spawn (move || {
+        spawn(move || {
             let mut websocket = accept(stream.unwrap()).unwrap();
             loop {
-                let msg = websocket.read_message().unwrap();
-
-                // We do not want to send back ping/pong messages.
-                if msg.is_binary() || msg.is_text() {
-                    websocket.write_message(msg).unwrap();
+                match websocket.read_message() {
+                    Ok(msg) => {
+                        // We do not want to send back ping/pong messages.
+                        if msg.is_binary() || msg.is_text() {
+                            websocket.write_message(msg).unwrap();
+                        }
+                    }
+                    Err(_) => {}
                 }
             }
         });


### PR DESCRIPTION
Properly match on message, so client disconnect doesn't trigger a panic