### PR TITLE
Update net2 to 0.2.37

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ version = "0.22"
 criterion = "0.3.4"
 env_logger = "0.9.0"
 input_buffer = "0.5.0"
-net2 = "0.2.33"
+net2 = "0.2.37"
 rand = "0.8.4"
 
 [[bench]]


### PR DESCRIPTION
Versions older than `0.2.36` incorrectly assume the layout of `SocketAddr`. https://github.com/deprecrated/net2-rs/issues/105