### PR TITLE
Downgrade MSRV to 1.56

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tungstenite/0.17.1"
 repository = "https://github.com/snapview/tungstenite-rs"
 version = "0.17.1"
 edition = "2018"
-rust-version = "1.58"
+rust-version = "1.56"
 include = ["benches/**/*", "src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -131,7 +131,7 @@ fn generate_request(mut request: Request) -> Result<(Vec<u8>, String)> {
         let value = headers.remove(header).ok_or_else(|| {
             Error::Protocol(ProtocolError::InvalidHeader(HeaderName::from_static(header)))
         })?;
-        write!(req, "{header}: {value}\r\n", value = value.to_str()?).unwrap();
+        write!(req, "{header}: {value}\r\n", header = header, value = value.to_str()?).unwrap();
     }
 
     // Now we must ensure that the headers that we've written once are not anymore present in the map.
@@ -296,7 +296,9 @@ mod tests {
             Upgrade: websocket\r\n\
             Sec-WebSocket-Version: 13\r\n\
             Sec-WebSocket-Key: {key}\r\n\
-            \r\n"
+            \r\n",
+            host = host,
+            key = key
         )
         .into_bytes()
     }


### PR DESCRIPTION
This is currently blocking us for [upgrading kube-rs](https://github.com/kube-rs/kube-rs/pull/839), since we have some build time regressions on rustc 1.57-1.58.