### PR TITLE
Downgrade MSRV to 1.51

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tungstenite/0.17.2"
 repository = "https://github.com/snapview/tungstenite-rs"
 version = "0.17.2"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.51"
 include = ["benches/**/*", "src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -129,7 +129,7 @@ fn generate_request(mut request: Request) -> Result<(Vec<u8>, String)> {
     //
     // See similar problem in `hyper`: https://github.com/hyperium/hyper/issues/1492
     let headers = request.headers_mut();
-    for header in WEBSOCKET_HEADERS {
+    for &header in &WEBSOCKET_HEADERS {
         let value = headers.remove(header).ok_or_else(|| {
             Error::Protocol(ProtocolError::InvalidHeader(
                 HeaderName::from_bytes(header.as_bytes()).unwrap(),


### PR DESCRIPTION
It would be nice to keep the MSRV low
- to have wider compatibility with Linux distros and Rust installs
- to not force breaking changes on dependent crates using tungstenite internally that have lower MSRV than tungstenite itself (like [serenity](https://github.com/serenity-rs/serenity))