### PR TITLE
fix: uppercase origin header

### DIFF
--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -158,6 +158,10 @@ fn generate_request(mut request: Request) -> Result<(Vec<u8>, String)> {
             name = "Sec-WebSocket-Protocol";
         }
 
+        if name == "origin" {
+            name = "Origin";
+        }
+
         writeln!(req, "{}: {}\r", name, v.to_str()?).unwrap();
     }
 


### PR DESCRIPTION
While HTTP headers should be case-insensitive, unfortunately some servers don't conform to that behavior. Unfortunately, the `http` crate always stores headers in lowercase without any way to prevent that behavior, so if we run into a server that does not conform to spec, we're doomed.
This is a workaround to that issue - it changes the `origin` header into `Origin`.
