### PR TITLE
tests: add a regression test for the queue logic

### DIFF
--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -199,6 +199,14 @@ impl FrameCodec {
 }
 
 #[cfg(test)]
+impl FrameCodec {
+    /// Returns the size of the output buffer.
+    pub(super) fn output_buffer_len(&self) -> usize {
+        self.out_buffer.len()
+    }
+}
+
+#[cfg(test)]
 mod tests {
 
     use crate::error::{CapacityError, Error};


### PR DESCRIPTION
We've recently [had a new PR](https://github.com/snapview/tungstenite-rs/pull/291) that added some useful things but unfortunately caused a regression in the queue logic. The PR was consequently reverted, but one of the key learnings was that we did not have a queue logic covered by a test.

It would be nice if we had a test in place to cover this case. This PR adds such a test. Having this test would allow us to rebuild the desired logic in the correct way while keeping the queue logic sound.