### PR TITLE
Error response on client type returns request body upon non receiving non 101 status code from server

### DIFF
--- a/examples/callback-error.rs
+++ b/examples/callback-error.rs
@@ -13,7 +13,7 @@ fn main() {
             let callback = |_req: &Request, _resp| {
                 let resp = Response::builder()
                     .status(StatusCode::FORBIDDEN)
-                    .body("Access denied".into())
+                    .body(Some("Access denied".into()))
                     .unwrap();
                 Err(resp)
             };

--- a/examples/callback-error.rs
+++ b/examples/callback-error.rs
@@ -13,7 +13,7 @@ fn main() {
             let callback = |_req: &Request, _resp| {
                 let resp = Response::builder()
                     .status(StatusCode::FORBIDDEN)
-                    .body(Some("Access denied".into()))
+                    .body("Access denied".into())
                     .unwrap();
                 Err(resp)
             };

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,7 +65,7 @@ pub enum Error {
     /// HTTP error.
     #[error("HTTP error: {}", .0.status())]
     #[cfg(feature = "handshake")]
-    Http(Response<Option<String>>),
+    Http(Response<Vec<u8>>),
     /// HTTP format error.
     #[error("HTTP format error: {0}")]
     #[cfg(feature = "handshake")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,7 +65,7 @@ pub enum Error {
     /// HTTP error.
     #[error("HTTP error: {}", .0.status())]
     #[cfg(feature = "handshake")]
-    Http(Response<Vec<u8>>),
+    Http(Response<Option<Vec<u8>>>),
     /// HTTP format error.
     #[error("HTTP format error: {0}")]
     #[cfg(feature = "handshake")]

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -26,7 +26,7 @@ use crate::{
 pub type Request = HttpRequest<()>;
 
 /// Client response type.
-pub type Response = HttpResponse<()>;
+pub type Response = HttpResponse<Option<String>>;
 
 /// Client handshake role.
 #[derive(Debug)]
@@ -83,7 +83,7 @@ impl<S: Read + Write> HandshakeRole for ClientHandshake<S> {
                 ProcessingResult::Continue(HandshakeMachine::start_read(stream))
             }
             StageResult::DoneReading { stream, result, tail } => {
-                let result = self.verify_data.verify_response(result)?;
+                let result = self.verify_data.verify_response(result, &tail)?;
                 debug!("Client handshake done.");
                 let websocket =
                     WebSocket::from_partially_read(stream, tail, Role::Client, self.config);
@@ -178,11 +178,12 @@ struct VerifyData {
 }
 
 impl VerifyData {
-    pub fn verify_response(&self, response: Response) -> Result<Response> {
+    pub fn verify_response(&self, mut response: Response, tail: &[u8]) -> Result<Response> {
         // 1. If the status code received from the server is not 101, the
         // client handles the response per HTTP [RFC2616] procedures. (RFC 6455)
         if response.status() != StatusCode::SWITCHING_PROTOCOLS {
-            return Err(Error::Http(response.map(|_| None)));
+            *response.body_mut() = Some(String::from_utf8_lossy(tail).to_string());
+            return Err(Error::Http(response));
         }
 
         let headers = response.headers();
@@ -255,7 +256,7 @@ impl<'h, 'b: 'h> FromHttparse<httparse::Response<'h, 'b>> for Response {
 
         let headers = HeaderMap::from_httparse(raw.headers)?;
 
-        let mut response = Response::new(());
+        let mut response = Response::new(None);
         *response.status_mut() = StatusCode::from_u16(raw.code.expect("Bug: no HTTP status code"))?;
         *response.headers_mut() = headers;
         // TODO: httparse only supports HTTP 0.9/1.0/1.1 but not HTTP 2.0

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -30,7 +30,7 @@ pub type Request = HttpRequest<()>;
 pub type Response = HttpResponse<()>;
 
 /// Server error response type.
-pub type ErrorResponse = HttpResponse<Option<String>>;
+pub type ErrorResponse = HttpResponse<Vec<u8>>;
 
 fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
     if request.method() != http::Method::GET {
@@ -265,9 +265,7 @@ impl<S: Read + Write, C: Callback> HandshakeRole for ServerHandshake<S, C> {
                         let mut output = vec![];
                         write_response(&mut output, resp)?;
 
-                        if let Some(body) = resp.body() {
-                            output.extend_from_slice(body.as_bytes());
-                        }
+                        output.extend_from_slice(resp.body());
 
                         ProcessingResult::Continue(HandshakeMachine::start_write(stream, output))
                     }


### PR DESCRIPTION
modified `client::Response` type to contain `String` instead of `()` to achieve this.

I ran into this issue yesterday when my automated test suite failed unexpectedly. Notably, fixing this doesn't conflict with RFC 6455, or RFC 2616.

> If the status code received from the server is not 101, the
       client handles the response per HTTP [[RFC2616](https://www.rfc-editor.org/rfc/rfc2616)] procedures.  In
       particular, the client might perform authentication if it
       receives a 401 status code; the server might redirect the client
       using a 3xx status code (but clients are not required to follow
       them), etc.  Otherwise, proceed as follows.

So I've given it a shot. Modified `Response` to wrap a `String` instead of `()` - a significant breaking api change. Would it be better to return a `Vec<u8>` or `Cow`? Or is there some way to do this that doesn't require modifying `Response<()>`?

Keen to hear other suggestions as to avoid the breaking api change. :)

closes #199 and addresses snapview/tokio-tungstenite#162