### PR TITLE
New API `connect_to_raw_stream` added

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -120,14 +120,14 @@ pub fn connect_with_config<Req: IntoClientRequest>(
 /// you want to use other TLS libraries, use `client` instead.
 ///
 /// [readme]: https://github.com/snapview/tungstenite-rs/#features
-pub fn connect_to_raw_stream<Req: IntoClientRequest>(
+pub fn connect_to_raw_stream<Req: IntoClientRequest, Stream: Read + Write + NoDelay>(
     request: Req,
-    stream: TcpStream,
-) -> Result<(WebSocket<MaybeTlsStream<TcpStream>>, Response)> {
-    fn try_client_handshake(
+    stream: Stream,
+) -> Result<(WebSocket<MaybeTlsStream<Stream>>, Response)> {
+    fn try_client_handshake<Stream: Read + Write + NoDelay>(
         request: Request,
-        mut stream: TcpStream,
-    ) -> Result<(WebSocket<MaybeTlsStream<TcpStream>>, Response)> {
+        mut stream: Stream,
+    ) -> Result<(WebSocket<MaybeTlsStream<Stream>>, Response)> {
         NoDelay::set_nodelay(&mut stream, true)?;
 
         #[cfg(not(any(feature = "native-tls", feature = "__rustls-tls")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use crate::{
 
 #[cfg(feature = "handshake")]
 pub use crate::{
-    client::{client, connect},
+    client::{client, connect, connect_to_raw_stream},
     handshake::{client::ClientHandshake, server::ServerHandshake, HandshakeError},
     server::{accept, accept_hdr, accept_hdr_with_config, accept_with_config},
 };


### PR DESCRIPTION
We need a new API that create WebSocket object from an exist socket. likes
```
        let url = "ws://123.45.67.89:1002/my_path";
        let stream = std::net::TcpStream::connect(("123.45.67.89", 1002))?;
        let (mut socket, response) = tungstenite::connect_to_raw_stream(url, stream)?;
        ...
```