### PR TITLE
Mark some functions to public

### DIFF
--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -94,7 +94,7 @@ impl<S: Read + Write> HandshakeRole for ClientHandshake<S> {
 }
 
 /// Verifies and generates a client WebSocket request from the original request and extracts a WebSocket key from it.
-fn generate_request(mut request: Request) -> Result<(Vec<u8>, String)> {
+pub fn generate_request(mut request: Request) -> Result<(Vec<u8>, String)> {
     let mut req = Vec::new();
     write!(
         req,

--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -1,3 +1,5 @@
+//! handshake machine.
+
 use bytes::Buf;
 use log::*;
 use std::io::{Cursor, Read, Write};

--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -101,6 +101,7 @@ pub enum RoundResult<Obj, Stream> {
 #[derive(Debug)]
 pub enum StageResult<Obj, Stream> {
     /// Reading round finished.
+    #[allow(missing_docs)]
     DoneReading { result: Obj, stream: Stream, tail: Vec<u8> },
     /// Writing round finished.
     DoneWriting(Stream),

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -3,8 +3,6 @@
 pub mod client;
 pub mod headers;
 pub mod server;
-
-#[allow(missing_docs)]
 pub mod machine;
 
 use std::{

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -4,7 +4,8 @@ pub mod client;
 pub mod headers;
 pub mod server;
 
-mod machine;
+#[allow(missing_docs)]
+pub mod machine;
 
 use std::{
     error::Error as ErrorTrait,

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -93,8 +93,7 @@ pub fn create_response_with_body<T>(
     Ok(create_parts(request)?.body(generate_body())?)
 }
 
-// Assumes that this is a valid response
-#[allow(missing_docs)]
+/// Write response to the stream `w`.
 pub fn write_response<T>(mut w: impl io::Write, response: &HttpResponse<T>) -> Result<()> {
     writeln!(
         w,

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -94,7 +94,8 @@ pub fn create_response_with_body<T>(
 }
 
 // Assumes that this is a valid response
-fn write_response<T>(mut w: impl io::Write, response: &HttpResponse<T>) -> Result<()> {
+#[allow(missing_docs)]
+pub fn write_response<T>(mut w: impl io::Write, response: &HttpResponse<T>) -> Result<()> {
     writeln!(
         w,
         "{version:?} {status}\r",


### PR DESCRIPTION
I'm writing a proxy app that needs to pre-read the data received inside the stream, and then try to parse the data to see if it conforms to the websocket protocol, rather than having tungstenite consume the data. Therefore, some functions of the parsing and encoding engine of the websocket protocol need to be called, and these functions are hidden. So I should make them public.