### PR TITLE
`UnexpectedEof` returned after sending and receiving close frame

### DIFF
--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -151,7 +151,13 @@ impl FrameCodec {
             }
 
             // Not enough data in buffer.
-            let size = self.in_buffer.read_from(stream)?;
+            let size = self.in_buffer.read_from(stream).or_else(|error| {
+                if error.kind() == IoErrorKind::UnexpectedEof {
+                    Ok(0)
+                } else {
+                    Err(error)
+                }
+            })?;
             if size == 0 {
                 trace!("no frame received");
                 return Ok(None);


### PR DESCRIPTION
After having sent and received a close frame, calling `read_message` or `write_pending` returns `Error::Io` of type `UnexpectedEof` instead of a `Error::ConnectionClosed`. This PR tries to fix this by unconditionally handling `UnexpectedEof` errors as having succesfully read 0 bytes from the stream.

Another way to fix this would be to change `WebSocketState::check_active` to return `Error::ConnectionClosed` for `WebSocketState::CloseAcknowledged`, but I think that modifies `WebSocketState`'s semantics.
