### PR TITLE
Switch from base64 0.20 to data-encoding 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 
 [features]
 default = ["handshake"]
-handshake = ["base64", "http", "httparse", "sha1", "url"]
+handshake = ["data-encoding", "http", "httparse", "sha1", "url"]
 native-tls = ["native-tls-crate"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
 rustls-tls-native-roots = ["__rustls-tls", "rustls-native-certs"]
@@ -27,7 +27,7 @@ rustls-tls-webpki-roots = ["__rustls-tls", "webpki-roots"]
 __rustls-tls = ["rustls", "webpki"]
 
 [dependencies]
-base64 = { version = "0.20.0", optional = true }
+data-encoding = { version = "2", optional = true }
 byteorder = "1.3.2"
 bytes = "1.0"
 http = { version = "0.2", optional = true }

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -279,7 +279,7 @@ pub fn generate_key() -> String {
     // a base64-encoded (see Section 4 of [RFC4648]) value that,
     // when decoded, is 16 bytes in length (RFC 6455)
     let r: [u8; 16] = rand::random();
-    base64::encode(&r)
+    data_encoding::BASE64.encode(&r)
 }
 
 #[cfg(test)]

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -120,7 +120,7 @@ pub fn derive_accept_key(request_key: &[u8]) -> String {
     let mut sha1 = Sha1::default();
     sha1.update(request_key);
     sha1.update(WS_GUID);
-    base64::encode(&sha1.finalize())
+    data_encoding::BASE64.encode(&sha1.finalize())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
base64 0.21 deprecated the simple API and requires quite a bit more code for the simple usage here, while data-encoding provides exactly the API needed and is also actively maintained.