### PR TITLE
docs: message.rs comment typo

### DIFF
--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -213,7 +213,7 @@ impl Message {
         matches!(*self, Message::Pong(_))
     }
 
-    /// Indicates whether a message ia s close message.
+    /// Indicates whether a message is a close message.
     pub fn is_close(&self) -> bool {
         matches!(*self, Message::Close(_))
     }


### PR DESCRIPTION
Simple typo fix of is_close() method comment