### PR TITLE
Display correct payload in Frame::fmt

### DIFF
--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -385,7 +385,7 @@ payload: 0x{}
             // self.mask.map(|mask| format!("{:?}", mask)).unwrap_or("NONE".into()),
             self.len(),
             self.payload.len(),
-            self.payload.iter().map(|byte| format!("{:x}", byte)).collect::<String>()
+            self.payload.iter().map(|byte| format!("{:02x}", byte)).collect::<String>()
         )
     }
 }


### PR DESCRIPTION
Current behavior (example):

```
2023-02-11T23:09:47.255396Z TRACE tungstenite::protocol::frame: received frame
<FRAME>
final: true
reserved: false false false
opcode: BINARY
length: 45
payload length: 43
payload: 0x8374000464016464036e696c64026f7061b64017364036e696c64017464036e696c
```

See https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=d306cadb79c84629d4b92b41bbaf8bd6 for how this PR (should) change this output. Big warning that I have not tested this, because the fix seems trivial.