### PR TITLE
Fix not compiling features rustls-tls-native-roots and rustls-tls-webpki-roots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ version = "0.6.0"
 [dependencies.webpki]
 optional = true
 version = "0.22"
+features = ["std"]
 
 [dependencies.webpki-roots]
 optional = true

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -107,7 +107,7 @@ mod encryption {
                                 for cert in rustls_native_certs::load_native_certs()? {
                                     root_store
                                         .add(&rustls::Certificate(cert.0))
-                                        .map_err(TlsError::Webpki)?;
+                                        .map_err(TlsError::Rustls)?;
                                 }
                             }
                             #[cfg(feature = "rustls-tls-webpki-roots")]


### PR DESCRIPTION
Fixes #344 