### PR TITLE
Use `rustls-webpki` instead of `webpki`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ native-tls = ["native-tls-crate"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
 rustls-tls-native-roots = ["__rustls-tls", "rustls-native-certs"]
 rustls-tls-webpki-roots = ["__rustls-tls", "webpki-roots"]
-__rustls-tls = ["rustls", "webpki"]
+__rustls-tls = ["rustls", "rustls-webpki"]
 
 [dependencies]
 data-encoding = { version = "2", optional = true }
@@ -52,9 +52,9 @@ version = "0.21.0"
 optional = true
 version = "0.6.0"
 
-[dependencies.webpki]
+[dependencies.rustls-webpki]
 optional = true
-version = "0.22"
+version = "0.100.1"
 features = ["std"]
 
 [dependencies.webpki-roots]


### PR DESCRIPTION
It hasn't seen a new version in two years.

The `rustls-webpki` crate is a fork of `webpki` which is maintained by the rustls project.