### PR TITLE
Rework to remove implicit flushes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# Unreleased (0.20.0)
+- Remove many implicit flushing behaviours. In general reading and writing messages will no 
+  longer flush until calling `flush`. An exception is automatic responses (e.g. pongs) 
+  which will continue to be written and flushed when reading and writing.
+  This allows writing a batch of messages and flushing once.
+- Add `WebSocket::read`, `write`, `send`, `flush`. Deprecate `read_message`, `write_message`, `write_pending`.
+- Add `FrameSocket::read`, `write`, `send`, `flush`. Remove `read_frame`, `write_frame`, `write_pending`. 
+  Note: Previous use of `write_frame` may be replaced with `send`.
+- Add `WebSocketContext::read`, `write`, `flush`. Remove `read_message`, `write_message`, `write_pending`.
+  Note: Previous use of `write_message` may be replaced with `write` + `flush`.
+- Remove `send_queue`, replaced with using the frame write buffer to achieve similar results.
+  * Add `WebSocketConfig::max_write_buffer_size`. Deprecate `max_send_queue`.
+  * Add `Error::WriteBufferFull`. Remove `Error::SendQueueFull`.
+    Note: `WriteBufferFull` returns the message that could not be written as a `Message::Frame`.
+
 # 0.19.0
 
 - Update TLS dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ rand = "0.8.4"
 name = "buffer"
 harness = false
 
+[[bench]]
+name = "write"
+harness = false
+
 [[example]]
 name = "client"
 required-features = ["handshake"]

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ fn main () {
         spawn (move || {
             let mut websocket = accept(stream.unwrap()).unwrap();
             loop {
-                let msg = websocket.read_message().unwrap();
+                let msg = websocket.read().unwrap();
 
                 // We do not want to send back ping/pong messages.
                 if msg.is_binary() || msg.is_text() {
-                    websocket.write_message(msg).unwrap();
+                    websocket.send(msg).unwrap();
                 }
             }
         });

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -1,0 +1,67 @@
+//! Benchmarks for write performance.
+use criterion::{BatchSize, Criterion};
+use std::{
+    hint,
+    io::{self, Read, Write},
+    time::{Duration, Instant},
+};
+use tungstenite::{Message, WebSocket};
+
+const MOCK_WRITE_LEN: usize = 8 * 1024 * 1024;
+
+/// `Write` impl that simulates fast writes and slow flushes.
+///
+/// Buffers up to 8 MiB fast on `write`. Each `flush` takes ~100ns.
+struct MockSlowFlushWrite(Vec<u8>);
+
+impl Read for MockSlowFlushWrite {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::new(io::ErrorKind::WouldBlock, "reads not supported"))
+    }
+}
+impl Write for MockSlowFlushWrite {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.0.len() + buf.len() > MOCK_WRITE_LEN {
+            self.flush()?;
+        }
+        self.0.extend(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if !self.0.is_empty() {
+            // simulate 100ns io
+            let a = Instant::now();
+            while a.elapsed() < Duration::from_nanos(100) {
+                hint::spin_loop();
+            }
+            self.0.clear();
+        }
+        Ok(())
+    }
+}
+
+fn benchmark(c: &mut Criterion) {
+    // Writes 100k small json text messages then calls `write_pending`
+    c.bench_function("write 100k small texts then flush", |b| {
+        let mut ws = WebSocket::from_raw_socket(
+            MockSlowFlushWrite(Vec::with_capacity(MOCK_WRITE_LEN)),
+            tungstenite::protocol::Role::Server,
+            None,
+        );
+
+        b.iter_batched(
+            || (0..100_000).map(|i| Message::Text(format!("{{\"id\":{i}}}"))),
+            |batch| {
+                for msg in batch {
+                    ws.write_message(msg).unwrap();
+                }
+                ws.write_pending().unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion::criterion_group!(write_benches, benchmark);
+criterion::criterion_main!(write_benches);

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -42,7 +42,7 @@ impl Write for MockSlowFlushWrite {
 }
 
 fn benchmark(c: &mut Criterion) {
-    // Writes 100k small json text messages then calls `write_pending`
+    // Writes 100k small json text messages then flushes
     c.bench_function("write 100k small texts then flush", |b| {
         let mut ws = WebSocket::from_raw_socket(
             MockSlowFlushWrite(Vec::with_capacity(MOCK_WRITE_LEN)),
@@ -54,9 +54,9 @@ fn benchmark(c: &mut Criterion) {
             || (0..100_000).map(|i| Message::Text(format!("{{\"id\":{i}}}"))),
             |batch| {
                 for msg in batch {
-                    ws.write_message(msg).unwrap();
+                    ws.write(msg).unwrap();
                 }
-                ws.write_pending().unwrap();
+                ws.flush().unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -7,7 +7,7 @@ const AGENT: &str = "Tungstenite";
 
 fn get_case_count() -> Result<u32> {
     let (mut socket, _) = connect(Url::parse("ws://localhost:9001/getCaseCount").unwrap())?;
-    let msg = socket.read_message()?;
+    let msg = socket.read()?;
     socket.close(None)?;
     Ok(msg.into_text()?.parse::<u32>().unwrap())
 }
@@ -26,9 +26,9 @@ fn run_test(case: u32) -> Result<()> {
         Url::parse(&format!("ws://localhost:9001/runCase?case={}&agent={}", case, AGENT)).unwrap();
     let (mut socket, _) = connect(case_url)?;
     loop {
-        match socket.read_message()? {
+        match socket.read()? {
             msg @ Message::Text(_) | msg @ Message::Binary(_) => {
-                socket.write_message(msg)?;
+                socket.send(msg)?;
             }
             Message::Ping(_) | Message::Pong(_) | Message::Close(_) | Message::Frame(_) => {}
         }

--- a/examples/autobahn-server.rs
+++ b/examples/autobahn-server.rs
@@ -17,9 +17,9 @@ fn handle_client(stream: TcpStream) -> Result<()> {
     let mut socket = accept(stream).map_err(must_not_block)?;
     info!("Running test");
     loop {
-        match socket.read_message()? {
+        match socket.read()? {
             msg @ Message::Text(_) | msg @ Message::Binary(_) => {
-                socket.write_message(msg)?;
+                socket.send(msg)?;
             }
             Message::Ping(_) | Message::Pong(_) | Message::Close(_) | Message::Frame(_) => {}
         }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -14,9 +14,9 @@ fn main() {
         println!("* {}", header);
     }
 
-    socket.write_message(Message::Text("Hello WebSocket".into())).unwrap();
+    socket.send(Message::Text("Hello WebSocket".into())).unwrap();
     loop {
-        let msg = socket.read_message().expect("Error reading message");
+        let msg = socket.read().expect("Error reading message");
         println!("Received: {}", msg);
     }
     // socket.close(None);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -28,9 +28,9 @@ fn main() {
             let mut websocket = accept_hdr(stream.unwrap(), callback).unwrap();
 
             loop {
-                let msg = websocket.read_message().unwrap();
+                let msg = websocket.read().unwrap();
                 if msg.is_binary() || msg.is_text() {
-                    websocket.write_message(msg).unwrap();
+                    websocket.send(msg).unwrap();
                 }
             }
         });

--- a/examples/srv_accept_unmasked_frames.rs
+++ b/examples/srv_accept_unmasked_frames.rs
@@ -27,14 +27,12 @@ fn main() {
             };
 
             let config = Some(WebSocketConfig {
-                max_send_queue: None,
-                max_message_size: None,
-                max_frame_size: None,
                 // This setting allows to accept client frames which are not masked
                 // This is not in compliance with RFC 6455 but might be handy in some
                 // rare cases where it is necessary to integrate with existing/legacy
                 // clients which are sending unmasked frames
                 accept_unmasked_frames: true,
+                ..<_>::default()
             });
 
             let mut websocket = accept_hdr_with_config(stream.unwrap(), callback, config).unwrap();

--- a/examples/srv_accept_unmasked_frames.rs
+++ b/examples/srv_accept_unmasked_frames.rs
@@ -38,7 +38,7 @@ fn main() {
             let mut websocket = accept_hdr_with_config(stream.unwrap(), callback, config).unwrap();
 
             loop {
-                let msg = websocket.read_message().unwrap();
+                let msg = websocket.read().unwrap();
                 if msg.is_binary() || msg.is_text() {
                     println!("received message {}", msg);
                 }

--- a/fuzz/fuzz_targets/read_message_client.rs
+++ b/fuzz/fuzz_targets/read_message_client.rs
@@ -33,5 +33,5 @@ fuzz_target!(|data: &[u8]| {
     //let vector: Vec<u8> = data.into();
     let cursor = Cursor::new(data);
     let mut socket = WebSocket::from_raw_socket(WriteMoc(cursor), Role::Client, None);
-    socket.read_message().ok();
+    socket.read().ok();
 });

--- a/fuzz/fuzz_targets/read_message_server.rs
+++ b/fuzz/fuzz_targets/read_message_server.rs
@@ -33,5 +33,5 @@ fuzz_target!(|data: &[u8]| {
     //let vector: Vec<u8> = data.into();
     let cursor = Cursor::new(data);
     let mut socket = WebSocket::from_raw_socket(WriteMoc(cursor), Role::Server, None);
-    socket.read_message().ok();
+    socket.read().ok();
 });

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,9 +53,9 @@ pub enum Error {
     /// Protocol violation.
     #[error("WebSocket protocol error: {0}")]
     Protocol(#[from] ProtocolError),
-    /// Message send queue full.
-    #[error("Send queue is full")]
-    SendQueueFull(Message),
+    /// Message write buffer is full.
+    #[error("Write buffer is full")]
+    WriteBufferFull(Message),
     /// UTF coding error.
     #[error("UTF-8 encoding error")]
     Utf8,

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -185,7 +185,7 @@ impl Message {
         Message::Text(string.into())
     }
 
-    /// Create a new binary WebSocket message by converting to Vec<u8>.
+    /// Create a new binary WebSocket message by converting to `Vec<u8>`.
     pub fn binary<B>(bin: B) -> Message
     where
         B: Into<Vec<u8>>,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -6,13 +6,6 @@ mod message;
 
 pub use self::{frame::CloseFrame, message::Message};
 
-use log::*;
-use std::{
-    collections::VecDeque,
-    io::{ErrorKind as IoErrorKind, Read, Write},
-    mem::replace,
-};
-
 use self::{
     frame::{
         coding::{CloseCode, Control as OpCtl, Data as OpData, OpCode},
@@ -23,6 +16,11 @@ use self::{
 use crate::{
     error::{Error, ProtocolError, Result},
     util::NonBlockingResult,
+};
+use log::*;
+use std::{
+    io::{ErrorKind as IoErrorKind, Read, Write},
+    mem::replace,
 };
 
 /// Indicates a Client or Server role of the websocket
@@ -37,10 +35,12 @@ pub enum Role {
 /// The configuration for WebSocket connection.
 #[derive(Debug, Clone, Copy)]
 pub struct WebSocketConfig {
-    /// The size of the send queue. You can use it to turn on/off the backpressure features. `None`
-    /// means here that the size of the queue is unlimited. The default value is the unlimited
-    /// queue.
+    /// Does nothing, instead use `max_write_buffer_size`.
+    #[deprecated]
     pub max_send_queue: Option<usize>,
+    /// The max size of the write buffer in bytes. Setting this can provide backpressure.
+    /// The default value is unlimited.
+    pub max_write_buffer_size: usize,
     /// The maximum size of a message. `None` means no size limit. The default value is 64 MiB
     /// which should be reasonably big for all normal use-cases but small enough to prevent
     /// memory eating by a malicious user.
@@ -60,8 +60,10 @@ pub struct WebSocketConfig {
 
 impl Default for WebSocketConfig {
     fn default() -> Self {
+        #[allow(deprecated)]
         WebSocketConfig {
             max_send_queue: None,
+            max_write_buffer_size: usize::MAX,
             max_message_size: Some(64 << 20),
             max_frame_size: Some(16 << 20),
             accept_unmasked_frames: false,
@@ -162,17 +164,24 @@ impl<Stream: Read + Write> WebSocket<Stream> {
         self.context.read_message(&mut self.socket)
     }
 
-    /// Send a message to stream, if possible.
+    /// Write a message to the provided stream, if possible.
     ///
-    /// WebSocket will buffer a configurable number of messages at a time, except to reply to Ping
-    /// requests. A Pong reply will jump the queue because the
+    /// A subsequent call should be made to [`Self::write_pending`] to flush writes.
+    ///
+    /// In the event of stream write failure the message frame will be stored
+    /// in the write buffer and will try again on the next call to [`Self::write_message`] or [`Self::write_pending`].
+    ///
+    /// If the write buffer would exceed the configured [`WebSocketConfig::max_write_buffer_size`]
+    /// `Err(WriteBufferFull(msg_frame))` is returned.
+    ///
+    /// This call will not flush, except to reply to Ping
+    /// requests. A Pong reply will flush early because the
     /// [websocket RFC](https://tools.ietf.org/html/rfc6455#section-5.5.2) specifies it should be sent
     /// as soon as is practical.
     ///
     /// Note that upon receiving a ping message, tungstenite cues a pong reply automatically.
-    /// When you call either `read_message`, `write_message` or `write_pending` next it will try to send
-    /// that pong out if the underlying connection can take more data. This means you should not
-    /// respond to ping frames manually.
+    /// When you call either `read_message`, `write_message` or `write_pending` next it will try to
+    /// write & flush the pong reply if possible. This means you should not respond to ping frames manually.
     ///
     /// You can however send pong frames manually in order to indicate a unidirectional heartbeat
     /// as described in [RFC 6455](https://tools.ietf.org/html/rfc6455#section-5.5.3). Note that
@@ -181,19 +190,19 @@ impl<Stream: Read + Write> WebSocket<Stream> {
     /// ping will not be sent, but rather replaced by your custom pong message.
     ///
     /// ## Errors
-    /// - If the WebSocket's send queue is full, `SendQueueFull` will be returned
-    /// along with the passed message. Otherwise, the message is queued and Ok(()) is returned.
-    /// - If the connection is closed and should be dropped, this will return [Error::ConnectionClosed].
-    /// - If you try again after [Error::ConnectionClosed] was returned either from here or from `read_message`,
-    ///   [Error::AlreadyClosed] will be returned. This indicates a program error on your part.
-    /// - [Error::Io] is returned if the underlying connection returns an error
+    /// - If the WebSocket's write buffer is full, [`Error::WriteBufferFull`] will be returned
+    ///   along with the equivalent passed message frame. Otherwise, the message is queued and Ok(()) is returned.
+    /// - If the connection is closed and should be dropped, this will return [`Error::ConnectionClosed`].
+    /// - If you try again after [`Error::ConnectionClosed`] was returned either from here or from `read_message`,
+    ///   [`Error::AlreadyClosed`] will be returned. This indicates a program error on your part.
+    /// - [`Error::Io`] is returned if the underlying connection returns an error
     ///   (consider these fatal except for WouldBlock).
-    /// - [Error::Capacity] if your message size is bigger than the configured max message size.
+    /// - [`Error::Capacity`] if your message size is bigger than the configured max message size.
     pub fn write_message(&mut self, message: Message) -> Result<()> {
         self.context.write_message(&mut self.socket, message)
     }
 
-    /// Flush the pending send queue.
+    /// Flush pending writes.
     pub fn write_pending(&mut self) -> Result<()> {
         self.context.write_pending(&mut self.socket)
     }
@@ -235,10 +244,8 @@ pub struct WebSocketContext {
     state: WebSocketState,
     /// Receive: an incomplete message being processed.
     incomplete: Option<IncompleteMessage>,
-    /// Send: a data send queue.
-    send_queue: VecDeque<Frame>,
-    /// Send: an OOB pong message.
-    pong: Option<Frame>,
+    /// Send in addition to regular messages E.g. "pong" or "close".
+    additional_send: Option<Frame>,
     /// The configuration for the websocket session.
     config: WebSocketConfig,
 }
@@ -246,28 +253,32 @@ pub struct WebSocketContext {
 impl WebSocketContext {
     /// Create a WebSocket context that manages a post-handshake stream.
     pub fn new(role: Role, config: Option<WebSocketConfig>) -> Self {
+        let config = config.unwrap_or_default();
+
         WebSocketContext {
             role,
-            frame: FrameCodec::new(),
+            frame: FrameCodec::new().with_max_out_buffer_len(config.max_write_buffer_size),
             state: WebSocketState::Active,
             incomplete: None,
-            send_queue: VecDeque::new(),
-            pong: None,
-            config: config.unwrap_or_default(),
+            additional_send: None,
+            config,
         }
     }
 
     /// Create a WebSocket context that manages an post-handshake stream.
     pub fn from_partially_read(part: Vec<u8>, role: Role, config: Option<WebSocketConfig>) -> Self {
+        let config = config.unwrap_or_default();
         WebSocketContext {
-            frame: FrameCodec::from_partially_read(part),
-            ..WebSocketContext::new(role, config)
+            frame: FrameCodec::from_partially_read(part)
+                .with_max_out_buffer_len(config.max_write_buffer_size),
+            ..WebSocketContext::new(role, Some(config))
         }
     }
 
     /// Change the configuration.
     pub fn set_config(&mut self, set_func: impl FnOnce(&mut WebSocketConfig)) {
-        set_func(&mut self.config)
+        set_func(&mut self.config);
+        self.frame.set_max_out_buffer_len(self.config.max_write_buffer_size);
     }
 
     /// Read the configuration.
@@ -299,12 +310,19 @@ impl WebSocketContext {
         Stream: Read + Write,
     {
         // Do not read from already closed connections.
-        self.state.check_active()?;
+        self.state.check_not_terminated()?;
 
         loop {
-            // Since we may get ping or close, we need to reply to the messages even during read.
-            // Thus we call write_pending() but ignore its blocking.
-            self.write_pending(stream).no_block()?;
+            if self.additional_send.is_some() {
+                // Since we may get ping or close, we need to reply to the messages even during read.
+                // Thus we call write_pending() but ignore its blocking.
+                self.write_pending(stream).no_block()?;
+            } else if self.role == Role::Server && !self.state.can_read() {
+                self.state = WebSocketState::Terminated;
+                return Err(Error::ConnectionClosed);
+            }
+
+            // TODO don't flush writes when reading
             // If we get here, either write blocks or we have nothing to write.
             // Thus if read blocks, just let it return WouldBlock.
             if let Some(message) = self.read_message_frame(stream)? {
@@ -314,37 +332,28 @@ impl WebSocketContext {
         }
     }
 
-    /// Send a message to the provided stream, if possible.
+    /// Write a message to the provided stream, if possible.
     ///
-    /// WebSocket will buffer a configurable number of messages at a time, except to reply to Ping
-    /// and Close requests. If the WebSocket's send queue is full, `SendQueueFull` will be returned
-    /// along with the passed message. Otherwise, the message is queued and Ok(()) is returned.
+    /// A subsequent call should be made to [`Self::write_pending`] to flush writes.
     ///
-    /// Note that only the last pong frame is stored to be sent, and only the
+    /// In the event of stream write failure the message frame will be stored
+    /// in the write buffer and will try again on the next call to [`Self::write_message`] or [`Self::write_pending`].
+    ///
+    /// If the write buffer would exceed the configured [`WebSocketConfig::max_write_buffer_size`]
+    /// `Err(WriteBufferFull(msg_frame))` is returned.
+    ///
+    /// Note that only the latest pong frame is stored to be sent, so only the
     /// most recent pong frame is sent if multiple pong frames are queued.
     pub fn write_message<Stream>(&mut self, stream: &mut Stream, message: Message) -> Result<()>
     where
         Stream: Read + Write,
     {
         // When terminated, return AlreadyClosed.
-        self.state.check_active()?;
+        self.state.check_not_terminated()?;
 
         // Do not write after sending a close frame.
         if !self.state.is_active() {
             return Err(Error::Protocol(ProtocolError::SendAfterClosing));
-        }
-
-        if let Some(max_send_queue) = self.config.max_send_queue {
-            if self.send_queue.len() >= max_send_queue {
-                // Try to make some room for the new message.
-                // Do not return here if write would block, ignore WouldBlock silently
-                // since we must queue the message anyway.
-                self.write_pending(stream).no_block()?;
-            }
-
-            if self.send_queue.len() >= max_send_queue {
-                return Err(Error::SendQueueFull(message));
-            }
         }
 
         let frame = match message {
@@ -352,49 +361,55 @@ impl WebSocketContext {
             Message::Binary(data) => Frame::message(data, OpCode::Data(OpData::Binary), true),
             Message::Ping(data) => Frame::ping(data),
             Message::Pong(data) => {
-                self.pong = Some(Frame::pong(data));
-                return self.write_queue(stream);
+                self.set_additional(Frame::pong(data));
+                // Note: user pongs can be user flushed so no need to flush here
+                return self.write(stream, None).map(|_| ());
             }
             Message::Close(code) => return self.close(stream, code),
             Message::Frame(f) => f,
         };
 
-        self.send_queue.push_back(frame);
-        self.write_queue(stream)
+        let should_flush = self.write(stream, Some(frame))?;
+        if should_flush {
+            self.write_pending(stream)?;
+        }
+        Ok(())
     }
 
-    /// Flush the pending send queue.
+    /// Flush pending writes.
     #[inline]
     pub fn write_pending<Stream>(&mut self, stream: &mut Stream) -> Result<()>
     where
         Stream: Read + Write,
     {
-        self.write_queue(stream)?;
+        _ = self.write(stream, None)?;
         Ok(stream.flush()?)
     }
 
     /// Write send queue & pongs.
     ///
     /// Does **not** flush.
-    fn write_queue<Stream>(&mut self, stream: &mut Stream) -> Result<()>
+    ///
+    /// Returns if the write contents indicate we should flush immediately.
+    fn write<Stream>(&mut self, stream: &mut Stream, data: Option<Frame>) -> Result<bool>
     where
         Stream: Read + Write,
     {
+        match data {
+            Some(data) => self.write_one_frame(stream, data)?,
+            None => self.frame.write_out_buffer(stream)?,
+        }
+
         // Upon receipt of a Ping frame, an endpoint MUST send a Pong frame in
         // response, unless it already received a Close frame. It SHOULD
         // respond with Pong frame as soon as is practical. (RFC 6455)
-        if let Some(pong) = self.pong.take() {
-            trace!("Sending pong reply");
-            self.send_one_frame(stream, pong)?;
-        }
-        // If we have any unsent frames, send them.
-        trace!("Frames still in queue: {}", self.send_queue.len());
-        while let Some(data) = self.send_queue.pop_front() {
-            self.send_one_frame(stream, data)?;
-        }
-
-        // If we get to this point, the send queue is empty and the underlying socket is still
-        // willing to take more data.
+        let should_flush = if let Some(msg) = self.additional_send.take() {
+            trace!("Sending pong/close");
+            self.write_one_frame(stream, msg)?;
+            true
+        } else {
+            false
+        };
 
         // If we're closing and there is nothing to send anymore, we should close the connection.
         if self.role == Role::Server && !self.state.can_read() {
@@ -407,7 +422,7 @@ impl WebSocketContext {
             self.state = WebSocketState::Terminated;
             Err(Error::ConnectionClosed)
         } else {
-            Ok(())
+            Ok(should_flush)
         }
     }
 
@@ -423,11 +438,11 @@ impl WebSocketContext {
         if let WebSocketState::Active = self.state {
             self.state = WebSocketState::ClosedByUs;
             let frame = Frame::close(code);
-            self.send_queue.push_back(frame);
+            self.write(stream, Some(frame))?;
         } else {
             // Already closed, nothing to do.
         }
-        self.write_pending(stream)
+        Ok(stream.flush()?)
     }
 
     /// Try to decode one message frame. May return None.
@@ -496,7 +511,7 @@ impl WebSocketContext {
                             let data = frame.into_data();
                             // No ping processing after we sent a close frame.
                             if self.state.is_active() {
-                                self.pong = Some(Frame::pong(data.clone()));
+                                self.set_additional(Frame::pong(data.clone()));
                             }
                             Ok(Some(Message::Ping(data)))
                         }
@@ -580,7 +595,7 @@ impl WebSocketContext {
 
                 let reply = Frame::close(close.clone());
                 debug!("Replying to close with {:?}", reply);
-                self.send_queue.push_back(reply);
+                self.set_additional(reply);
 
                 Some(close)
             }
@@ -597,8 +612,8 @@ impl WebSocketContext {
         }
     }
 
-    /// Send a single pending frame.
-    fn send_one_frame<Stream>(&mut self, stream: &mut Stream, mut frame: Frame) -> Result<()>
+    /// Write a single frame into the stream via the write-buffer.
+    fn write_one_frame<Stream>(&mut self, stream: &mut Stream, mut frame: Frame) -> Result<()>
     where
         Stream: Read + Write,
     {
@@ -613,6 +628,17 @@ impl WebSocketContext {
 
         trace!("Sending frame: {:?}", frame);
         self.frame.write_frame(stream, frame).check_connection_reset(self.state)
+    }
+
+    /// Replace `additional_send` if it is currently a `Pong` message.
+    fn set_additional(&mut self, add: Frame) {
+        let empty_or_pong = self
+            .additional_send
+            .as_ref()
+            .map_or(true, |f| f.header().opcode == OpCode::Control(OpCtl::Pong));
+        if empty_or_pong {
+            self.additional_send.replace(add);
+        }
     }
 }
 
@@ -645,7 +671,7 @@ impl WebSocketState {
     }
 
     /// Check if the state is active, return error if not.
-    fn check_active(self) -> Result<()> {
+    fn check_not_terminated(self) -> Result<()> {
         match self {
             WebSocketState::Terminated => Err(Error::AlreadyClosed),
             _ => Ok(()),
@@ -694,64 +720,6 @@ mod tests {
     impl<Stream: io::Read> io::Read for WriteMoc<Stream> {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
             self.0.read(buf)
-        }
-    }
-
-    struct WouldBlockStreamMoc;
-
-    impl io::Write for WouldBlockStreamMoc {
-        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
-            Err(io::Error::new(io::ErrorKind::WouldBlock, "would block"))
-        }
-        fn flush(&mut self) -> io::Result<()> {
-            Err(io::Error::new(io::ErrorKind::WouldBlock, "would block"))
-        }
-    }
-
-    impl io::Read for WouldBlockStreamMoc {
-        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
-            Err(io::Error::new(io::ErrorKind::WouldBlock, "would block"))
-        }
-    }
-
-    #[test]
-    fn queue_logic() {
-        // Create a socket with the queue size of 1.
-        let mut socket = WebSocket::from_raw_socket(
-            WouldBlockStreamMoc,
-            Role::Client,
-            Some(WebSocketConfig { max_send_queue: Some(1), ..Default::default() }),
-        );
-
-        // Test message that we're going to send.
-        let message = Message::Binary(vec![0xFF; 1024]);
-
-        // Helper to check the error.
-        let assert_would_block = |error| {
-            if let Error::Io(io_error) = error {
-                assert_eq!(io_error.kind(), io::ErrorKind::WouldBlock);
-            } else {
-                panic!("Expected WouldBlock error");
-            }
-        };
-
-        // The first attempt of writing must not fail, since the queue is empty at start.
-        // But since the underlying mock object always returns `WouldBlock`, so is the result.
-        assert_would_block(dbg!(socket.write_message(message.clone()).unwrap_err()));
-
-        // Any subsequent attempts must return an error telling that the queue is full.
-        for _i in 0..100 {
-            assert!(matches!(
-                socket.write_message(message.clone()).unwrap_err(),
-                Error::SendQueueFull(..)
-            ));
-        }
-
-        // The size of the output buffer must not be bigger than the size of that message
-        // that we managed to write to the output buffer at first. Since we could not make
-        // any progress (because of the logic of the moc buffer), the size remains unchanged.
-        if socket.context.frame.output_buffer_len() > message.len() {
-            panic!("Too many frames in the queue");
         }
     }
 

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -52,27 +52,27 @@ fn test_server_close() {
     do_test(
         3012,
         |mut cli_sock| {
-            cli_sock.write_message(Message::Text("Hello WebSocket".into())).unwrap();
+            cli_sock.send(Message::Text("Hello WebSocket".into())).unwrap();
 
-            let message = cli_sock.read_message().unwrap(); // receive close from server
+            let message = cli_sock.read().unwrap(); // receive close from server
             assert!(message.is_close());
 
-            let err = cli_sock.read_message().unwrap_err(); // now we should get ConnectionClosed
+            let err = cli_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
                 _ => panic!("unexpected error: {:?}", err),
             }
         },
         |mut srv_sock| {
-            let message = srv_sock.read_message().unwrap();
+            let message = srv_sock.read().unwrap();
             assert_eq!(message.into_data(), b"Hello WebSocket");
 
             srv_sock.close(None).unwrap(); // send close to client
 
-            let message = srv_sock.read_message().unwrap(); // receive acknowledgement
+            let message = srv_sock.read().unwrap(); // receive acknowledgement
             assert!(message.is_close());
 
-            let err = srv_sock.read_message().unwrap_err(); // now we should get ConnectionClosed
+            let err = srv_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
                 _ => panic!("unexpected error: {:?}", err),
@@ -86,26 +86,26 @@ fn test_evil_server_close() {
     do_test(
         3013,
         |mut cli_sock| {
-            cli_sock.write_message(Message::Text("Hello WebSocket".into())).unwrap();
+            cli_sock.send(Message::Text("Hello WebSocket".into())).unwrap();
 
             sleep(Duration::from_secs(1));
 
-            let message = cli_sock.read_message().unwrap(); // receive close from server
+            let message = cli_sock.read().unwrap(); // receive close from server
             assert!(message.is_close());
 
-            let err = cli_sock.read_message().unwrap_err(); // now we should get ConnectionClosed
+            let err = cli_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
                 _ => panic!("unexpected error: {:?}", err),
             }
         },
         |mut srv_sock| {
-            let message = srv_sock.read_message().unwrap();
+            let message = srv_sock.read().unwrap();
             assert_eq!(message.into_data(), b"Hello WebSocket");
 
             srv_sock.close(None).unwrap(); // send close to client
 
-            let message = srv_sock.read_message().unwrap(); // receive acknowledgement
+            let message = srv_sock.read().unwrap(); // receive acknowledgement
             assert!(message.is_close());
             // and now just drop the connection without waiting for `ConnectionClosed`
             srv_sock.get_mut().set_linger(Some(Duration::from_secs(0))).unwrap();
@@ -119,32 +119,32 @@ fn test_client_close() {
     do_test(
         3014,
         |mut cli_sock| {
-            cli_sock.write_message(Message::Text("Hello WebSocket".into())).unwrap();
+            cli_sock.send(Message::Text("Hello WebSocket".into())).unwrap();
 
-            let message = cli_sock.read_message().unwrap(); // receive answer from server
+            let message = cli_sock.read().unwrap(); // receive answer from server
             assert_eq!(message.into_data(), b"From Server");
 
             cli_sock.close(None).unwrap(); // send close to server
 
-            let message = cli_sock.read_message().unwrap(); // receive acknowledgement from server
+            let message = cli_sock.read().unwrap(); // receive acknowledgement from server
             assert!(message.is_close());
 
-            let err = cli_sock.read_message().unwrap_err(); // now we should get ConnectionClosed
+            let err = cli_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
                 _ => panic!("unexpected error: {:?}", err),
             }
         },
         |mut srv_sock| {
-            let message = srv_sock.read_message().unwrap();
+            let message = srv_sock.read().unwrap();
             assert_eq!(message.into_data(), b"Hello WebSocket");
 
-            srv_sock.write_message(Message::Text("From Server".into())).unwrap();
+            srv_sock.send(Message::Text("From Server".into())).unwrap();
 
-            let message = srv_sock.read_message().unwrap(); // receive close from client
+            let message = srv_sock.read().unwrap(); // receive close from client
             assert!(message.is_close());
 
-            let err = srv_sock.read_message().unwrap_err(); // now we should get ConnectionClosed
+            let err = srv_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
                 _ => panic!("unexpected error: {:?}", err),

--- a/tests/no_send_after_close.rs
+++ b/tests/no_send_after_close.rs
@@ -29,10 +29,10 @@ fn test_no_send_after_close() {
     let client_thread = spawn(move || {
         let (mut client, _) = connect(Url::parse("ws://localhost:3013/socket").unwrap()).unwrap();
 
-        let message = client.read_message().unwrap(); // receive close from server
+        let message = client.read().unwrap(); // receive close from server
         assert!(message.is_close());
 
-        let err = client.read_message().unwrap_err(); // now we should get ConnectionClosed
+        let err = client.read().unwrap_err(); // now we should get ConnectionClosed
         match err {
             Error::ConnectionClosed => {}
             _ => panic!("unexpected error: {:?}", err),
@@ -44,7 +44,7 @@ fn test_no_send_after_close() {
 
     client_handler.close(None).unwrap(); // send close to client
 
-    let err = client_handler.write_message(Message::Text("Hello WebSocket".into()));
+    let err = client_handler.send(Message::Text("Hello WebSocket".into()));
 
     assert!(err.is_err());
 

--- a/tests/receive_after_init_close.rs
+++ b/tests/receive_after_init_close.rs
@@ -29,12 +29,12 @@ fn test_receive_after_init_close() {
     let client_thread = spawn(move || {
         let (mut client, _) = connect(Url::parse("ws://localhost:3013/socket").unwrap()).unwrap();
 
-        client.write_message(Message::Text("Hello WebSocket".into())).unwrap();
+        client.send(Message::Text("Hello WebSocket".into())).unwrap();
 
-        let message = client.read_message().unwrap(); // receive close from server
+        let message = client.read().unwrap(); // receive close from server
         assert!(message.is_close());
 
-        let err = client.read_message().unwrap_err(); // now we should get ConnectionClosed
+        let err = client.read().unwrap_err(); // now we should get ConnectionClosed
         match err {
             Error::ConnectionClosed => {}
             _ => panic!("unexpected error: {:?}", err),
@@ -47,12 +47,12 @@ fn test_receive_after_init_close() {
     client_handler.close(None).unwrap(); // send close to client
 
     // This read should succeed even though we already initiated a close
-    let message = client_handler.read_message().unwrap();
+    let message = client_handler.read().unwrap();
     assert_eq!(message.into_data(), b"Hello WebSocket");
 
-    assert!(client_handler.read_message().unwrap().is_close()); // receive acknowledgement
+    assert!(client_handler.read().unwrap().is_close()); // receive acknowledgement
 
-    let err = client_handler.read_message().unwrap_err(); // now we should get ConnectionClosed
+    let err = client_handler.read().unwrap_err(); // now we should get ConnectionClosed
     match err {
         Error::ConnectionClosed => {}
         _ => panic!("unexpected error: {:?}", err),


### PR DESCRIPTION
My context: I've been working on a websocket load generator service that will write lots of small json message events to it's ws clients. I was interested in having a high peak throughput from this service to allow me to test downstream load performance. It uses axum->tokio-tungstenite->tungstenite. Doing localhost testing I got **~1.2M msg/s** peak throughput. This PR improves that to **~2M msg/s**.

Because of this improvement I thought this PR may be worthwhile.

### Summary: Reduce flushing and allow better control of when flushes happen
I noticed there was a lot of flushing happening. Currently flushing is done something like:
* Before writing each message.
* After writing each message.
* Before reading each message.

This seems excessive particularly when trying to send batches of lots of small messages. This PR minimises flushes so that a flush will only occur if `write_pending` is called, or if a "system message" (pong/close) should be dispatched. So users can call `write_message` many times without flushing (which is more like how I expected it to behave), then call `write_pending` which will flush.

### Impl notes
My first approach was to remove the flush before each frame write currently in `WebSocketContext::write_pending`
```rust
// First, make sure we have no pending frame sending.
self.frame.write_pending(stream)?;
```
And remove the flush after each `FrameCodec::write_frame`. Then wire up `write_message` to **not** call flush and `write_pending` to essentially _be_ flush.

#### Flush before write & `send_queue`
I noticed that after these changes the `WebSocketContext::send_queue` no longer really seemed to do much. The logic as is actually **requires** flushing before each write to work otherwise a message is simply added to the `send_queue` then taken off it and put in the `FrameCodec::out_buffer`.

So I removed the `send_queue` since it no longer does anything. It didn't seem to do too much previously, as it could only build up there if flushing before each write returned an error. If the write itself returned an error the send_queue would be empty and the message will simply be stored in the `FrameCodec::out_buffer`. I'm not sure what the benefit of having both a send_queue and an out_buffer is/was?

This PR I replace the `send_queue` by using the existing `out_buffer`. Writes are buffered there without flushing before each. We can buffer many writes here, as was done before, but without any send queue.

I replaced the `max_send_queue` config with `max_write_buffer_size` which can bound the previously unbound `out_buffer`. If a write would exceed this bound the message is instead returned as an error, in a very similar way previous logic would handle the `send_queue` bound. The one difference here is the messages is returned as a `Message::Frame` since it has already been serialized at this point. This seems worse than before where the message was returned as it was given. However, logic to re-send should still work. I'm not sure this difference is worth the flush call to prevent. It might be possible to put in a conversion back to the old message somehow but I'm not sure it's worth it.

#### Flush after each write
Removing this seems straightforward. We now require the caller calls `write_pending` after any writes to guarantee it will be flushed. This requirement seems similar to most write interfaces.

An exception is "system messages" like pong responses. If these have been scheduled we'll still automatically flush.

#### Flush on each read
Currently `WebSocketContext::read_message` will flush **writes** on each call.
```rust
// Since we may get ping or close, we need to reply to the messages even during read.
// Thus we call write_pending() but ignore its blocking.
self.write_pending(stream).no_block()?;
```

This means that if my service is polling for incoming messages I can still end up flushing writes a lot more than I'd expect. This PR changes this to only write if we actually have a pong/close "system message" to send. Since system messages won't scale with load this minimises extra flush impact while still writing-and-flushing these messages asap.

### micro-bench
I added a micro-bench `benches/write.rs` to reproduce flush cost. This simulates a `Write` impl that takes 100ns to flush. The scenario is 100k `write_message`s then one `write_pending`. E.g. how I would approach writing a batch of small messages with the current API.

The improvement is clear since this PR will call only one flush per batch.
```
write 100k small texts then flush
        time:   [6.1961 ms 6.2280 ms 6.2360 ms]
        change: [-66.921% -66.617% -66.309%] (p = 0.07 > 0.05)
```

### Issues
* The micro-bench is quite artificial. Perhaps it could be made more realistic without too much bloat?
* `Error::WriteBufferFull` will return the message as a `Message::Frame`, whereas `SendQueueFull` would return the message as given.
* This is a **breaking** change.
* It may be worth considering some API changes to reflect the changes. E.g. rename `write_pending` to `flush`?