### PR TITLE
Buffer writes before writing to the underlying stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Remove many implicit flushing behaviours. In general reading and writing messages will no 
   longer flush until calling `flush`. An exception is automatic responses (e.g. pongs) 
   which will continue to be written and flushed when reading and writing.
-  This allows writing a batch of messages and flushing once.
+  This allows writing a batch of messages and flushing once, improving performance.
 - Add `WebSocket::read`, `write`, `send`, `flush`. Deprecate `read_message`, `write_message`, `write_pending`.
 - Add `FrameSocket::read`, `write`, `send`, `flush`. Remove `read_frame`, `write_frame`, `write_pending`. 
   Note: Previous use of `write_frame` may be replaced with `send`.
@@ -12,6 +12,8 @@
   * Add `WebSocketConfig::max_write_buffer_size`. Deprecate `max_send_queue`.
   * Add `Error::WriteBufferFull`. Remove `Error::SendQueueFull`.
     Note: `WriteBufferFull` returns the message that could not be written as a `Message::Frame`.
+- Add ability to buffer multiple writes before writing to the underlying stream, controlled by
+  `WebSocketConfig::write_buffer_size` (default 128 KiB). Improves batch message write performance.
 
 # 0.19.0
 

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -9,35 +9,43 @@ use tungstenite::{Message, WebSocket};
 
 const MOCK_WRITE_LEN: usize = 8 * 1024 * 1024;
 
-/// `Write` impl that simulates fast writes and slow flushes.
+/// `Write` impl that simulates slowish writes and slow flushes.
 ///
-/// Buffers up to 8 MiB fast on `write`. Each `flush` takes ~100ns.
-struct MockSlowFlushWrite(Vec<u8>);
+/// Each `write` can buffer up to 8 MiB before flushing but takes an additional **~80ns**
+/// to simulate stuff going on in the underlying stream.
+/// Each `flush` takes **~8µs** to simulate flush io.
+struct MockWrite(Vec<u8>);
 
-impl Read for MockSlowFlushWrite {
+impl Read for MockWrite {
     fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
         Err(io::Error::new(io::ErrorKind::WouldBlock, "reads not supported"))
     }
 }
-impl Write for MockSlowFlushWrite {
+impl Write for MockWrite {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if self.0.len() + buf.len() > MOCK_WRITE_LEN {
             self.flush()?;
         }
+        // simulate io
+        spin(Duration::from_nanos(80));
         self.0.extend(buf);
         Ok(buf.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {
         if !self.0.is_empty() {
-            // simulate 100ns io
-            let a = Instant::now();
-            while a.elapsed() < Duration::from_nanos(100) {
-                hint::spin_loop();
-            }
+            // simulate io
+            spin(Duration::from_micros(8));
             self.0.clear();
         }
         Ok(())
+    }
+}
+
+fn spin(duration: Duration) {
+    let a = Instant::now();
+    while a.elapsed() < duration {
+        hint::spin_loop();
     }
 }
 
@@ -45,7 +53,7 @@ fn benchmark(c: &mut Criterion) {
     // Writes 100k small json text messages then flushes
     c.bench_function("write 100k small texts then flush", |b| {
         let mut ws = WebSocket::from_raw_socket(
-            MockSlowFlushWrite(Vec::with_capacity(MOCK_WRITE_LEN)),
+            MockWrite(Vec::with_capacity(MOCK_WRITE_LEN)),
             tungstenite::protocol::Role::Server,
             None,
         );

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -205,7 +205,9 @@ impl FrameCodec {
     /// If the out buffer size is over the `out_buffer_write_len` will also write
     /// the out buffer into the provided `stream`.
     ///
-    /// Does **not** flush.
+    /// To ensure buffered frames are written call [`Self::write_out_buffer`].
+    ///
+    /// May write to the stream, will **not** flush.
     pub(super) fn buffer_frame<Stream>(&mut self, stream: &mut Stream, frame: Frame) -> Result<()>
     where
         Stream: Write,

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -139,7 +139,7 @@ impl FrameCodec {
 
     /// Sets [`Self::buffer_frame`] buffer target length to reach before
     /// writing to the stream.
-    pub(super) fn set_target_buffer_write_len(&mut self, len: usize) {
+    pub(super) fn set_out_buffer_write_len(&mut self, len: usize) {
         self.out_buffer_write_len = len;
     }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -42,7 +42,7 @@ pub struct WebSocketConfig {
     /// to the underlying stream.
     /// The default value is 128 KiB.
     ///
-    /// Note: [`flush`](WebSocket::flush) will always be fully write the buffer regardless.
+    /// Note: [`flush`](WebSocket::flush) will always fully write the buffer regardless.
     pub write_buffer_size: usize,
     /// The max size of the write buffer in bytes. Setting this can provide backpressure
     /// in the case the write buffer is filling up due to write errors.

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -292,23 +292,17 @@ pub struct WebSocketContext {
 impl WebSocketContext {
     /// Create a WebSocket context that manages a post-handshake stream.
     pub fn new(role: Role, config: Option<WebSocketConfig>) -> Self {
-        let config = config.unwrap_or_default();
-        let mut frame = FrameCodec::new();
-        frame.set_max_out_buffer_len(config.max_write_buffer_size);
-        frame.set_out_buffer_write_len(config.write_buffer_size);
-        Self::_new(role, frame, config)
+        Self::_new(role, FrameCodec::new(), config.unwrap_or_default())
     }
 
     /// Create a WebSocket context that manages an post-handshake stream.
     pub fn from_partially_read(part: Vec<u8>, role: Role, config: Option<WebSocketConfig>) -> Self {
-        let config = config.unwrap_or_default();
-        let mut frame = FrameCodec::from_partially_read(part);
-        frame.set_max_out_buffer_len(config.max_write_buffer_size);
-        frame.set_out_buffer_write_len(config.write_buffer_size);
-        Self::_new(role, frame, config)
+        Self::_new(role, FrameCodec::from_partially_read(part), config.unwrap_or_default())
     }
 
-    fn _new(role: Role, frame: FrameCodec, config: WebSocketConfig) -> Self {
+    fn _new(role: Role, mut frame: FrameCodec, config: WebSocketConfig) -> Self {
+        frame.set_max_out_buffer_len(config.max_write_buffer_size);
+        frame.set_out_buffer_write_len(config.write_buffer_size);
         Self {
             role,
             frame,

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -1,0 +1,68 @@
+use std::io::{self, Read, Write};
+use tungstenite::{protocol::WebSocketConfig, Message, WebSocket};
+
+/// `Write` impl that records call stats and drops the data.
+#[derive(Debug, Default)]
+struct MockWrite {
+    written_bytes: usize,
+    write_count: usize,
+    flush_count: usize,
+}
+
+impl Read for MockWrite {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::new(io::ErrorKind::WouldBlock, "reads not supported"))
+    }
+}
+impl Write for MockWrite {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.written_bytes += buf.len();
+        self.write_count += 1;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_count += 1;
+        Ok(())
+    }
+}
+
+/// Test for write buffering and flushing behaviour.
+#[test]
+fn write_flush_behaviour() {
+    const SEND_ME_LEN: usize = 10;
+    const BATCH_ME_LEN: usize = 11;
+    const WRITE_BUFFER_SIZE: usize = 600;
+
+    let mut ws = WebSocket::from_raw_socket(
+        MockWrite::default(),
+        tungstenite::protocol::Role::Server,
+        Some(WebSocketConfig { write_buffer_size: WRITE_BUFFER_SIZE, ..<_>::default() }),
+    );
+
+    assert_eq!(ws.get_ref().written_bytes, 0);
+    assert_eq!(ws.get_ref().write_count, 0);
+    assert_eq!(ws.get_ref().flush_count, 0);
+
+    // `send` writes & flushes immediately
+    ws.send(Message::Text("Send me!".into())).unwrap();
+    assert_eq!(ws.get_ref().written_bytes, SEND_ME_LEN);
+    assert_eq!(ws.get_ref().write_count, 1);
+    assert_eq!(ws.get_ref().flush_count, 1);
+
+    // send a batch of messages
+    for msg in (0..100).map(|_| Message::Text("Batch me!".into())) {
+        ws.write(msg).unwrap();
+    }
+    // after 55 writes the out_buffer will exceed write_buffer_size=600
+    // and so do a single underlying write (not flushing).
+    assert_eq!(ws.get_ref().written_bytes, 55 * BATCH_ME_LEN + SEND_ME_LEN);
+    assert_eq!(ws.get_ref().write_count, 2);
+    assert_eq!(ws.get_ref().flush_count, 1);
+
+    // flushing will perform a single write for the remaining out_buffer & flush.
+    ws.flush().unwrap();
+    assert_eq!(ws.get_ref().written_bytes, 100 * BATCH_ME_LEN + SEND_ME_LEN);
+    assert_eq!(ws.get_ref().write_count, 3);
+    assert_eq!(ws.get_ref().flush_count, 2);
+}


### PR DESCRIPTION
Add ability to buffer multiple writes before writing to the underlying stream, controlled by `WebSocketConfig::write_buffer_size` (default 128 KiB). Improves batch message write performance.

This PR comes out of some further investigation this morning regarding writing many small messages. After #357 we no longer flush on each write which gives a big boost. I wondered what would happen if we also avoided/minimised `write` calls to the underlying stream and allowed the messages to buffer in the out_buffer/write buffer.

In short it does seem to provide a boost, though not as dramatic as the flush rework. With #357 my load-generator could write **~2.15M msg/s**, with 128KiB write_buffer_size this goes up to **~2.44M msg/s**.

Larger sizes didn't yield a benefit for me so 128KiB seems a decent default value, I'm proposing that here. The previous code essentially acted as if this value was zero, which could also be a reasonable default though users would need to opt in to get this benefit.

Note: This will only affect users that are calling `write` multiple times then `flush`. Since on `flush` all write buffer data will be written regardless of this config.

### Naming
There is a slight issue with naming clarity here `write_buffer_size` vs `max_write_buffer_size`. I've tried to clarify as much as possible in docs. Perhaps this can be improved?