### PR TITLE
Add assert panics for `WebSocketConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     Note: `WriteBufferFull` returns the message that could not be written as a `Message::Frame`.
 - Add ability to buffer multiple writes before writing to the underlying stream, controlled by
   `WebSocketConfig::write_buffer_size` (default 128 KiB). Improves batch message write performance.
+- Panic on receiving invalid `WebSocketConfig`.
 
 # 0.19.0
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -112,6 +112,9 @@ impl<Stream> WebSocket<Stream> {
     /// Call this function if you're using Tungstenite as a part of a web framework
     /// or together with an existing one. If you need an initial handshake, use
     /// `connect()` or `accept()` functions of the crate to construct a websocket.
+    ///
+    /// # Panics
+    /// Panics if config is invalid e.g. `max_write_buffer_size <= write_buffer_size`.
     pub fn from_raw_socket(stream: Stream, role: Role, config: Option<WebSocketConfig>) -> Self {
         WebSocket { socket: stream, context: WebSocketContext::new(role, config) }
     }
@@ -121,6 +124,9 @@ impl<Stream> WebSocket<Stream> {
     /// Call this function if you're using Tungstenite as a part of a web framework
     /// or together with an existing one. If you need an initial handshake, use
     /// `connect()` or `accept()` functions of the crate to construct a websocket.
+    ///
+    /// # Panics
+    /// Panics if config is invalid e.g. `max_write_buffer_size <= write_buffer_size`.
     pub fn from_partially_read(
         stream: Stream,
         part: Vec<u8>,
@@ -143,6 +149,9 @@ impl<Stream> WebSocket<Stream> {
     }
 
     /// Change the configuration.
+    ///
+    /// # Panics
+    /// Panics if config is invalid e.g. `max_write_buffer_size <= write_buffer_size`.
     pub fn set_config(&mut self, set_func: impl FnOnce(&mut WebSocketConfig)) {
         self.context.set_config(set_func)
     }
@@ -302,11 +311,17 @@ pub struct WebSocketContext {
 
 impl WebSocketContext {
     /// Create a WebSocket context that manages a post-handshake stream.
+    ///
+    /// # Panics
+    /// Panics if config is invalid e.g. `max_write_buffer_size <= write_buffer_size`.
     pub fn new(role: Role, config: Option<WebSocketConfig>) -> Self {
         Self::_new(role, FrameCodec::new(), config.unwrap_or_default())
     }
 
     /// Create a WebSocket context that manages an post-handshake stream.
+    ///
+    /// # Panics
+    /// Panics if config is invalid e.g. `max_write_buffer_size <= write_buffer_size`.
     pub fn from_partially_read(part: Vec<u8>, role: Role, config: Option<WebSocketConfig>) -> Self {
         Self::_new(role, FrameCodec::from_partially_read(part), config.unwrap_or_default())
     }
@@ -326,6 +341,9 @@ impl WebSocketContext {
     }
 
     /// Change the configuration.
+    ///
+    /// # Panics
+    /// Panics if config is invalid e.g. `max_write_buffer_size <= write_buffer_size`.
     pub fn set_config(&mut self, set_func: impl FnOnce(&mut WebSocketConfig)) {
         set_func(&mut self.config);
         self.config.assert_valid();

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -81,6 +81,17 @@ impl Default for WebSocketConfig {
     }
 }
 
+impl WebSocketConfig {
+    /// Panic if values are invalid.
+    pub(crate) fn assert_valid(&self) {
+        assert!(
+            self.max_write_buffer_size > self.write_buffer_size,
+            "WebSocketConfig::max_write_buffer_size must be greater than write_buffer_size, \
+            see WebSocketConfig docs`"
+        );
+    }
+}
+
 /// WebSocket input-output stream.
 ///
 /// This is THE structure you want to create to be able to speak the WebSocket protocol.
@@ -301,6 +312,7 @@ impl WebSocketContext {
     }
 
     fn _new(role: Role, mut frame: FrameCodec, config: WebSocketConfig) -> Self {
+        config.assert_valid();
         frame.set_max_out_buffer_len(config.max_write_buffer_size);
         frame.set_out_buffer_write_len(config.write_buffer_size);
         Self {
@@ -316,6 +328,7 @@ impl WebSocketContext {
     /// Change the configuration.
     pub fn set_config(&mut self, set_func: impl FnOnce(&mut WebSocketConfig)) {
         set_func(&mut self.config);
+        self.config.assert_valid();
         self.frame.set_max_out_buffer_len(self.config.max_write_buffer_size);
         self.frame.set_out_buffer_write_len(self.config.write_buffer_size);
     }


### PR DESCRIPTION
Based on hypotheticals in https://github.com/snapview/tokio-tungstenite/issues/286 & https://github.com/snapview/tokio-tungstenite/pull/287 this PR asserts that `WebSocketConfig::max_write_buffer_size` must be greater than `WebSocketConfig::write_buffer_size`.

Doing otherwise is a configuration mistake as writes would not be able function without errors.

Previously it was just docs, since if misconfigured the user would simply get lots of `WriteBufferFull` errors. I _think_ this panic will be better as it will inform the user and point them in the direction of the docs instead of thinking this behaviour a tungstenite bug?

## Alternative
We could instead move `WebSocketConfig` to a builder style, so itself could panic which puts the panic a bit closer to the source. But that's more of a change and may end up less ergonomic than what we have?