### PR TITLE
Config value for reading frames as passthrough

### DIFF
--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -172,7 +172,8 @@ pub enum Message {
     Pong(Vec<u8>),
     /// A close message with the optional close frame.
     Close(Option<CloseFrame<'static>>),
-    /// Raw frame. Note, that you're not going to get this value while reading the message.
+    /// Raw frame. These will be returned from the socket only if the `read_as_frames` option
+    /// in [WebSocketConfig] is set to `true`.
     Frame(Frame),
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -74,9 +74,10 @@ pub struct WebSocketConfig {
     /// some popular libraries that are sending unmasked frames, ignoring the RFC.
     /// By default this option is set to `false`, i.e. according to RFC 6455.
     pub accept_unmasked_frames: bool,
-    /// When set to `true`, the socket will read non-compliant frames that are well-formed,
-    /// but may be extended, i.e., some of the reserved bits are set. When such a frame
-    /// is encountered, it will be read and returned from the socket instead of dropped.
+    /// When set to `true`, all well-formed frames read by the socket will be returned as-is
+    /// with minimal processing. Close frames and masked frames will still be handled,
+    /// as they affect control flow, but fragmented or incomplete frames will be returned without
+    /// reassembly.
     /// Set to `false` by default
     pub read_as_frames: bool
 }


### PR DESCRIPTION
**Reasoning**
I've added this new, hopefully non-invasive config value to the `WebSocketConfig` struct to allow for the following:

-  Preserve extended frame headers (non-zero reserved bits, à la [RFC 7692](https://www.rfc-editor.org/rfc/rfc7692.html) ), until such a time as these are officially supported
- Facilitate true proxying by passing received frames as-is to upstream handlers with minimal interference
- Allow for post-processing of websocket frames in applications where current tungstenite configuration does not allow enough customization

We are currently working on a rust-based proxy project that uses a library that in turn uses tungstenite. We were experiencing issues proxying the websocket traffic and tracked the issue down to tungstenite dropping all extended frames. I see this as a temporary issue until negotiated extensions are handled by tungstenite, or a proper API for processing raw extended frames is provided.