### PR TITLE
Replace data-encoding with base64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 
 [features]
 default = ["handshake"]
-handshake = ["data-encoding", "http", "httparse", "sha1", "url"]
+handshake = ["base64", "http", "httparse", "sha1", "url"]
 native-tls = ["native-tls-crate"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
 rustls-tls-native-roots = ["__rustls-tls", "rustls-native-certs"]
@@ -27,7 +27,7 @@ rustls-tls-webpki-roots = ["__rustls-tls", "webpki-roots"]
 __rustls-tls = ["rustls"]
 
 [dependencies]
-data-encoding = { version = "2", optional = true }
+base64 = { version = "0.21.3", optional = true }
 byteorder = "1.3.2"
 bytes = "1.0"
 http = { version = "0.2", optional = true }

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -5,6 +5,7 @@ use std::{
     marker::PhantomData,
 };
 
+use base64::engine::Engine;
 use http::{
     header::HeaderName, HeaderMap, Request as HttpRequest, Response as HttpResponse, StatusCode,
 };
@@ -279,7 +280,7 @@ pub fn generate_key() -> String {
     // a base64-encoded (see Section 4 of [RFC4648]) value that,
     // when decoded, is 16 bytes in length (RFC 6455)
     let r: [u8; 16] = rand::random();
-    data_encoding::BASE64.encode(&r)
+    base64::engine::general_purpose::STANDARD.encode(&r)
 }
 
 #[cfg(test)]

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -11,6 +11,7 @@ use std::{
     io::{Read, Write},
 };
 
+use base64::engine::Engine;
 use sha1::{Digest, Sha1};
 
 use self::machine::{HandshakeMachine, RoundResult, StageResult, TryParse};
@@ -120,7 +121,7 @@ pub fn derive_accept_key(request_key: &[u8]) -> String {
     let mut sha1 = Sha1::default();
     sha1.update(request_key);
     sha1.update(WS_GUID);
-    data_encoding::BASE64.encode(&sha1.finalize())
+    base64::engine::general_purpose::STANDARD.encode(&sha1.finalize())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
data-encoding 2.5.0 raises their MSRV to 1.70,
meanwhile base64 has 0.21.3 reduced MSRV to 1.48 in order to be compatible with Debian Bullseye

https://github.com/ia0/data-encoding/pull/77
https://github.com/marshallpierce/rust-base64/pull/239
https://github.com/marshallpierce/rust-base64/pull/246

This also attempts to reduce dependencies for crates depending on both hyper & tungstenite-rs where headers/postgres-protocol/rustls-pemfile use base64 0.21