### PR TITLE
Replace deprecated `net2` dev dependency with `socket2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ version = "0.25"
 criterion = "0.5.0"
 env_logger = "0.10.0"
 input_buffer = "0.5.0"
-net2 = "0.2.37"
 rand = "0.8.4"
+socket2 = "0.5.5"
 
 [[bench]]
 name = "buffer"

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use net2::TcpStreamExt;
+use socket2::Socket;
 use tungstenite::{accept, connect, stream::MaybeTlsStream, Error, Message, WebSocket};
 use url::Url;
 
@@ -19,7 +19,7 @@ type Sock = WebSocket<MaybeTlsStream<TcpStream>>;
 fn do_test<CT, ST>(port: u16, client_task: CT, server_task: ST)
 where
     CT: FnOnce(Sock) + Send + 'static,
-    ST: FnOnce(WebSocket<TcpStream>),
+    ST: FnOnce(WebSocket<Socket>),
 {
     env_logger::try_init().ok();
 
@@ -40,7 +40,7 @@ where
     });
 
     let client_handler = server.incoming().next().unwrap();
-    let client_handler = accept(client_handler.unwrap()).unwrap();
+    let client_handler = accept(Socket::from(client_handler.unwrap())).unwrap();
 
     server_task(client_handler);
 


### PR DESCRIPTION
Closes: #382 