### PR TITLE
Update MSRV to 1.60 and check on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,30 @@ jobs:
       - name: Test
         run: cargo test --release
 
+  test-msvr:
+    name: Test MSRV
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust:
+          - 1.60.0
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Install dependencies
+        run: sudo apt-get install libssl-dev
+
+      - name: Check
+        run: cargo check
+
   autobahn:
     name: Autobahn tests
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tungstenite/0.21.0"
 repository = "https://github.com/snapview/tungstenite-rs"
 version = "0.21.0"
 edition = "2018"
-rust-version = "1.51"
+rust-version = "1.60"
 include = ["benches/**/*", "src/**/*", "examples/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
The code does not actually compile anymore with 1.51.

Also only run `cargo check` with 1.60 as various optional features, tests, benchmarks actually require newer Rust versions.