### PR TITLE
Fix handshake for `arti-client`

### DIFF
--- a/src/handshake/machine.rs
+++ b/src/handshake/machine.rs
@@ -73,6 +73,7 @@ impl<Stream: Read + Write> HandshakeMachine<Stream> {
             HandshakeState::Writing(mut buf) => {
                 assert!(buf.has_remaining());
                 if let Some(size) = self.stream.write(Buf::chunk(&buf)).no_block()? {
+                    self.stream.flush()?;
                     assert!(size > 0);
                     buf.advance(size);
                     Ok(if buf.has_remaining() {


### PR DESCRIPTION
As requirement for usage of `arti-client`, added a flush method call in the `HandshakeMachine` writing round.