### PR TITLE
Fix behavior when connecting wss url without TLS support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -52,6 +52,12 @@ pub fn connect_with_config<Req: IntoClientRequest>(
     ) -> Result<(WebSocket<MaybeTlsStream<TcpStream>>, Response)> {
         let uri = request.uri();
         let mode = uri_mode(uri)?;
+
+        #[cfg(not(any(feature = "native-tls", feature = "__rustls-tls")))]
+        if let Mode::Tls = mode {
+            return Err(Error::Url(UrlError::TlsFeatureNotEnabled));
+        }
+
         let host = request.uri().host().ok_or(Error::Url(UrlError::NoHostName))?;
         let host = if host.starts_with('[') { &host[1..host.len() - 1] } else { host };
         let port = uri.port_u16().unwrap_or(match mode {

--- a/tests/wss_fails_when_no_tls.rs
+++ b/tests/wss_fails_when_no_tls.rs
@@ -1,0 +1,10 @@
+#![cfg(not(any(feature = "native-tls", feature = "__rustls-tls")))]
+
+use tungstenite::{connect, error::UrlError, Error};
+
+#[test]
+fn wss_url_fails_when_no_tls_support() {
+    let ws = connect("wss://127.0.0.1/ws");
+    eprintln!("{:?}", ws);
+    assert!(matches!(ws, Err(Error::Url(UrlError::TlsFeatureNotEnabled))))
+}

--- a/tests/wss_fails_when_no_tls.rs
+++ b/tests/wss_fails_when_no_tls.rs
@@ -1,4 +1,4 @@
-#![cfg(not(any(feature = "native-tls", feature = "__rustls-tls")))]
+#![cfg(all(feature = "handshake", not(any(feature = "native-tls", feature = "__rustls-tls"))))]
 
 use tungstenite::{connect, error::UrlError, Error};
 


### PR DESCRIPTION
Hi,

  When compiled without TLS support, the client currently falls back to HTTP (and by default, on port 443) even if the URI has the `wss` scheme. This creates a problem that is hard to debug, as the call fails with a  generic WSS protocol error.

  If a `wss://` URI is requested and no TLS support is available, the client should fail fast with a `UrlError::TlsFeatureNotEnabled`.

Cheers,