### PR TITLE
deps: update `rustls-native-certs` to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ version = "1.0"
 
 [dependencies.rustls-native-certs]
 optional = true
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies.webpki-roots]
 optional = true


### PR DESCRIPTION
The `load_native_certs()` function now returns all errors instead of raising only the first error.

Not finding any native root CA certificates is not fatal if the "rustls-tls-webpki-roots" feature is enabled.