### PR TITLE
Update to Rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/snapview/tungstenite-rs"
 documentation = "https://docs.rs/tungstenite/0.24.0"
 repository = "https://github.com/snapview/tungstenite-rs"
 version = "0.24.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 include = ["benches/**/*", "src/**/*", "examples/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,6 @@
 //! Methods to connect to a WebSocket as a client.
 
 use std::{
-    convert::TryFrom,
     io::{Read, Write},
     net::{SocketAddr, TcpStream, ToSocketAddrs},
     result::Result as StdResult,

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -1,9 +1,4 @@
-use std::{
-    convert::{AsRef, From, Into, TryFrom},
-    fmt,
-    result::Result as StdResult,
-    str,
-};
+use std::{fmt, result::Result as StdResult, str};
 
 use super::frame::{CloseFrame, Frame};
 use crate::error::{CapacityError, Error, Result};

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -74,7 +74,6 @@ mod encryption {
         use rustls_pki_types::ServerName;
 
         use std::{
-            convert::TryFrom,
             io::{Read, Write},
             sync::Arc,
         };


### PR DESCRIPTION
The Rust edition can be updated to 2021 (1.56.0) because the MSRV is 1.63.0.