### PR TITLE
Fix clippy warnings for large error types

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -155,7 +155,6 @@ pub fn uri_mode(uri: &Uri) -> Result<Mode> {
 /// Use this function if you need a nonblocking handshake support or if you
 /// want to use a custom stream like `mio::net::TcpStream` or `openssl::ssl::SslStream`.
 /// Any stream supporting `Read + Write` will do.
-#[allow(clippy::result_large_err)]
 pub fn client_with_config<Stream, Req>(
     request: Req,
     stream: Stream,
@@ -173,7 +172,6 @@ where
 /// Use this function if you need a nonblocking handshake support or if you
 /// want to use a custom stream like `mio::net::TcpStream` or `openssl::ssl::SslStream`.
 /// Any stream supporting `Read + Write` will do.
-#[allow(clippy::result_large_err)]
 pub fn client<Stream, Req>(
     request: Req,
     stream: Stream,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@
     unused_imports,
     unused_import_braces
 )]
+// This can be removed when `error::Error::Http`, `handshake::HandshakeError::Interrupted` and
+// `handshake::server::ErrorResponse` are boxed.
+#![allow(clippy::result_large_err)]
 
 #[cfg(feature = "handshake")]
 pub use http;

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -175,7 +175,6 @@ type TlsHandshakeError<S> = HandshakeError<ClientHandshake<MaybeTlsStream<S>>>;
 
 /// Creates a WebSocket handshake from a request and a stream,
 /// upgrading the stream to TLS if required.
-#[allow(clippy::result_large_err)]
 pub fn client_tls<R, S>(
     request: R,
     stream: S,
@@ -192,7 +191,6 @@ where
 /// be created.
 ///
 /// Please refer to [`client_tls()`] for more details.
-#[allow(clippy::result_large_err)]
 pub fn client_tls_with_config<R, S>(
     request: R,
     stream: S,


### PR DESCRIPTION
This allows `clippy::result_large_err` on crate level to suppress warnings for:
- `error::Error::Http`
- `handshake::HandshakeError::Interrupted`
- `handshake::server::ErrorResponse`

See #449 and its failed clippy build job
https://github.com/snapview/tungstenite-rs/actions/runs/11774982034/job/32794544956