### PR TITLE
Trim optional separating whitespace in client protocols

### DIFF
--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -186,7 +186,7 @@ pub fn generate_request(mut request: Request) -> Result<(Vec<u8>, String)> {
 
 fn extract_subprotocols_from_request(request: &Request) -> Result<Option<Vec<String>>> {
     if let Some(subprotocols) = request.headers().get("Sec-WebSocket-Protocol") {
-        Ok(Some(subprotocols.to_str()?.split(',').map(ToString::to_string).collect()))
+        Ok(Some(subprotocols.to_str()?.split(',').map(|s| s.trim().to_string()).collect()))
     } else {
         Ok(None)
     }


### PR DESCRIPTION
This trims optional whitespace when extracting the advertised protocols from the client request, which is required to later verify that the server's response matches one of the protocols.

Fixes https://github.com/snapview/tungstenite-rs/issues/456