### PR TITLE
FEAT: Replace Vec<u8> with Bytes

### DIFF
--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -204,7 +204,6 @@ impl FrameHeader {
     }
 }
 
-
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Payload {
     Owned(Vec<u8>),
@@ -379,7 +378,10 @@ impl Frame {
     pub fn message(data: impl Into<Payload>, opcode: OpCode, is_final: bool) -> Frame {
         debug_assert!(matches!(opcode, OpCode::Data(_)), "Invalid opcode for data frame.");
 
-        Frame { header: FrameHeader { is_final, opcode, ..FrameHeader::default() }, payload: data.into() }
+        Frame {
+            header: FrameHeader { is_final, opcode, ..FrameHeader::default() },
+            payload: data.into(),
+        }
     }
 
     /// Create a new Pong control frame.

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -273,7 +273,10 @@ mod tests {
             sock.read(None).unwrap().unwrap().into_payload().as_bytes(),
             vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
         );
-        assert_eq!(sock.read(None).unwrap().unwrap().into_payload().as_bytes(), vec![0x03, 0x02, 0x01]);
+        assert_eq!(
+            sock.read(None).unwrap().unwrap().into_payload().as_bytes(),
+            vec![0x03, 0x02, 0x01]
+        );
         assert!(sock.read(None).unwrap().is_none());
 
         let (_, rest) = sock.into_inner();

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -270,10 +270,10 @@ mod tests {
         let mut sock = FrameSocket::new(raw);
 
         assert_eq!(
-            sock.read(None).unwrap().unwrap().into_data(),
+            sock.read(None).unwrap().unwrap().into_payload().as_bytes(),
             vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
         );
-        assert_eq!(sock.read(None).unwrap().unwrap().into_data(), vec![0x03, 0x02, 0x01]);
+        assert_eq!(sock.read(None).unwrap().unwrap().into_payload().as_bytes(), vec![0x03, 0x02, 0x01]);
         assert!(sock.read(None).unwrap().is_none());
 
         let (_, rest) = sock.into_inner();
@@ -285,7 +285,7 @@ mod tests {
         let raw = Cursor::new(vec![0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
         let mut sock = FrameSocket::from_partially_read(raw, vec![0x82, 0x07, 0x01]);
         assert_eq!(
-            sock.read(None).unwrap().unwrap().into_data(),
+            sock.read(None).unwrap().unwrap().into_payload().as_bytes(),
             vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
         );
     }

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -94,7 +94,9 @@ impl IncompleteMessage {
     pub fn new(message_type: IncompleteMessageType) -> Self {
         IncompleteMessage {
             collector: match message_type {
-                IncompleteMessageType::Binary => IncompleteMessageCollector::Binary(BytesMut::new()),
+                IncompleteMessageType::Binary => {
+                    IncompleteMessageCollector::Binary(BytesMut::new())
+                }
                 IncompleteMessageType::Text => {
                     IncompleteMessageCollector::Text(StringCollector::new())
                 }
@@ -219,10 +221,8 @@ impl Message {
     pub fn len(&self) -> usize {
         match *self {
             Message::Text(ref string) => string.len(),
-            Message::Binary(ref data)  => data.len(),
-            Message::Ping(ref data) | Message::Pong(ref data) => {
-                data.len()
-            }
+            Message::Binary(ref data) => data.len(),
+            Message::Ping(ref data) | Message::Pong(ref data) => data.len(),
             Message::Close(ref data) => data.as_ref().map(|d| d.reason.len()).unwrap_or(0),
             Message::Frame(ref frame) => frame.len(),
         }
@@ -238,7 +238,7 @@ impl Message {
     pub fn into_data(self) -> Vec<u8> {
         match self {
             Message::Text(string) => string.into_bytes(),
-            Message::Binary(data)  => data.into(),
+            Message::Binary(data) => data.into(),
             Message::Ping(data) | Message::Pong(data) => data,
             Message::Close(None) => Vec::new(),
             Message::Close(Some(frame)) => frame.reason.into_owned().into_bytes(),
@@ -251,9 +251,7 @@ impl Message {
         match self {
             Message::Text(string) => Ok(string),
             Message::Binary(data) => Ok(String::from_utf8(data.into())?),
-            Message::Ping(data) | Message::Pong(data) => {
-                Ok(String::from_utf8(data)?)
-            }
+            Message::Ping(data) | Message::Pong(data) => Ok(String::from_utf8(data)?),
             Message::Close(None) => Ok(String::new()),
             Message::Close(Some(frame)) => Ok(frame.reason.into_owned()),
             Message::Frame(frame) => Ok(frame.into_string()?),
@@ -266,9 +264,7 @@ impl Message {
         match *self {
             Message::Text(ref string) => Ok(string),
             Message::Binary(ref data) => Ok(str::from_utf8(data)?),
-            Message::Ping(ref data) | Message::Pong(ref data) => {
-                Ok(str::from_utf8(data)?)
-            }
+            Message::Ping(ref data) | Message::Pong(ref data) => Ok(str::from_utf8(data)?),
             Message::Close(None) => Ok(""),
             Message::Close(Some(ref frame)) => Ok(&frame.reason),
             Message::Frame(ref frame) => Ok(frame.to_text()?),


### PR DESCRIPTION
Hi I have given adding `Bytes` a try but I at some places I am not sure if there is a performance implication or not. This is a continuation of #104. This is the first time for me working with more low level network stuff so I might be missing one or two obvious things.

The breaking change here would be for users that use `Message::Binary())` instead of `Message::binary()` to construct the message. The fix for this is quite simple as they would have to just change it to `Message::Binary(data.into()))`. 

Let me know what you think. 

Thanks a lot and have a great day!