### PR TITLE
message: support `bytes::Bytes` as a payload type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ __rustls-tls = ["rustls", "rustls-pki-types"]
 [dependencies]
 data-encoding = { version = "2", optional = true }
 byteorder = "1.3.2"
-bytes = "1.0"
+bytes = "1.9.0"
 http = { version = "1.0", optional = true }
 httparse = { version = "1.3.4", optional = true }
 log = "0.4.8"

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -51,7 +51,10 @@ fn benchmark(c: &mut Criterion) {
                 for i in 0_u64..100_000 {
                     writer
                         .send(match i {
-                            _ if i % 3 == 0 => Message::Binary(i.to_le_bytes().into()),
+                            _ if i % 3 == 0 => {
+                                let data: Vec<u8> = i.to_le_bytes().into();
+                                Message::Binary(data.into())
+                            }
                             _ => Message::Text(format!("{{\"id\":{i}}}")),
                         })
                         .unwrap();

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -57,7 +57,10 @@ fn benchmark(c: &mut Criterion) {
         b.iter(|| {
             for i in 0_u64..100_000 {
                 let msg = match i {
-                    _ if i % 3 == 0 => Message::Binary(i.to_le_bytes().into()),
+                    _ if i % 3 == 0 => {
+                        let data: Vec<u8> = i.to_le_bytes().into();
+                        Message::Binary(data.into())
+                    }
                     _ => Message::Text(format!("{{\"id\":{i}}}")),
                 };
                 ws.write(msg).unwrap();

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -1,14 +1,17 @@
-use byteorder::{NetworkEndian, ReadBytesExt};
-use log::*;
 use std::{
     borrow::Cow,
     default::Default,
     fmt,
     io::{Cursor, ErrorKind, Read, Write},
+    mem,
     result::Result as StdResult,
     str::Utf8Error,
     string::{FromUtf8Error, String},
 };
+
+use byteorder::{NetworkEndian, ReadBytesExt};
+use bytes::Bytes;
+use log::*;
 
 use super::{
     coding::{CloseCode, Control, Data, OpCode},
@@ -203,11 +206,47 @@ impl FrameHeader {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum Payload {
+    Owned(Vec<u8>),
+    Shared(Bytes),
+}
+
+impl Payload {
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            Payload::Owned(v) => v,
+            Payload::Shared(v) => v,
+        }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        match self {
+            Payload::Owned(v) => &mut *v,
+            Payload::Shared(v) => {
+                // Using `Bytes::to_vec()` or `Vec::from(bytes.as_ref())` would mean making a copy.
+                // `Bytes::into()` would not make a copy if our `Bytes` instance is the only one.
+                let data = mem::take(v).into();
+                *self = Payload::Owned(data);
+                let Payload::Owned(v) = self else { unreachable!() };
+                v
+            }
+        }
+    }
+
+    pub fn into_data(self) -> Vec<u8> {
+        match self {
+            Payload::Owned(v) => v,
+            Payload::Shared(v) => v.into(),
+        }
+    }
+}
+
 /// A struct representing a WebSocket frame.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Frame {
     header: FrameHeader,
-    payload: Vec<u8>,
+    payload: Payload,
 }
 
 impl Frame {
@@ -215,7 +254,7 @@ impl Frame {
     /// This is the length of the header + the length of the payload.
     #[inline]
     pub fn len(&self) -> usize {
-        let length = self.payload.len();
+        let length = self.payload.as_slice().len();
         self.header.len(length as u64) + length
     }
 
@@ -239,14 +278,14 @@ impl Frame {
 
     /// Get a reference to the frame's payload.
     #[inline]
-    pub fn payload(&self) -> &Vec<u8> {
-        &self.payload
+    pub fn payload(&self) -> &[u8] {
+        self.payload.as_slice()
     }
 
     /// Get a mutable reference to the frame's payload.
     #[inline]
-    pub fn payload_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.payload
+    pub fn payload_mut(&mut self) -> &mut [u8] {
+        self.payload.as_mut_slice()
     }
 
     /// Test whether the frame is masked.
@@ -269,36 +308,36 @@ impl Frame {
     #[inline]
     pub(crate) fn apply_mask(&mut self) {
         if let Some(mask) = self.header.mask.take() {
-            apply_mask(&mut self.payload, mask);
+            apply_mask(self.payload.as_mut_slice(), mask);
         }
     }
 
     /// Consume the frame into its payload as binary.
     #[inline]
     pub fn into_data(self) -> Vec<u8> {
-        self.payload
+        self.payload.into_data()
     }
 
     /// Consume the frame into its payload as string.
     #[inline]
     pub fn into_string(self) -> StdResult<String, FromUtf8Error> {
-        String::from_utf8(self.payload)
+        String::from_utf8(self.payload.into_data())
     }
 
     /// Get frame payload as `&str`.
     #[inline]
     pub fn to_text(&self) -> Result<&str, Utf8Error> {
-        std::str::from_utf8(&self.payload)
+        std::str::from_utf8(self.payload.as_slice())
     }
 
     /// Consume the frame into a closing frame.
     #[inline]
     pub(crate) fn into_close(self) -> Result<Option<CloseFrame<'static>>> {
-        match self.payload.len() {
+        match self.payload.as_slice().len() {
             0 => Ok(None),
             1 => Err(Error::Protocol(ProtocolError::InvalidCloseSequence)),
             _ => {
-                let mut data = self.payload;
+                let mut data = self.payload.into_data();
                 let code = u16::from_be_bytes([data[0], data[1]]).into();
                 data.drain(0..2);
                 let text = String::from_utf8(data)?;
@@ -309,33 +348,36 @@ impl Frame {
 
     /// Create a new data frame.
     #[inline]
-    pub fn message(data: Vec<u8>, opcode: OpCode, is_final: bool) -> Frame {
+    pub fn message(data: impl Into<Bytes>, opcode: OpCode, is_final: bool) -> Frame {
         debug_assert!(matches!(opcode, OpCode::Data(_)), "Invalid opcode for data frame.");
 
-        Frame { header: FrameHeader { is_final, opcode, ..FrameHeader::default() }, payload: data }
+        Frame {
+            header: FrameHeader { is_final, opcode, ..FrameHeader::default() },
+            payload: Payload::Shared(data.into()),
+        }
     }
 
     /// Create a new Pong control frame.
     #[inline]
-    pub fn pong(data: Vec<u8>) -> Frame {
+    pub fn pong(data: impl Into<Bytes>) -> Frame {
         Frame {
             header: FrameHeader {
                 opcode: OpCode::Control(Control::Pong),
                 ..FrameHeader::default()
             },
-            payload: data,
+            payload: Payload::Shared(data.into()),
         }
     }
 
     /// Create a new Ping control frame.
     #[inline]
-    pub fn ping(data: Vec<u8>) -> Frame {
+    pub fn ping(data: impl Into<Bytes>) -> Frame {
         Frame {
             header: FrameHeader {
                 opcode: OpCode::Control(Control::Ping),
                 ..FrameHeader::default()
             },
-            payload: data,
+            payload: Payload::Shared(data.into()),
         }
     }
 
@@ -351,17 +393,17 @@ impl Frame {
             Vec::new()
         };
 
-        Frame { header: FrameHeader::default(), payload }
+        Frame { header: FrameHeader::default(), payload: Payload::Owned(payload) }
     }
 
     /// Create a frame from given header and data.
-    pub fn from_payload(header: FrameHeader, payload: Vec<u8>) -> Self {
-        Frame { header, payload }
+    pub fn from_payload(header: FrameHeader, payload: impl Into<Bytes>) -> Self {
+        Frame { header, payload: Payload::Shared(payload.into()) }
     }
 
     /// Write a frame out to a buffer
     pub fn format(mut self, output: &mut impl Write) -> Result<()> {
-        self.header.format(self.payload.len() as u64, output)?;
+        self.header.format(self.payload.as_slice().len() as u64, output)?;
         self.apply_mask();
         output.write_all(self.payload())?;
         Ok(())
@@ -390,8 +432,8 @@ payload: 0x{}
             self.header.opcode,
             // self.mask.map(|mask| format!("{:?}", mask)).unwrap_or("NONE".into()),
             self.len(),
-            self.payload.len(),
-            self.payload.iter().fold(String::new(), |mut output, byte| {
+            self.payload.as_slice().len(),
+            self.payload.as_slice().iter().fold(String::new(), |mut output, byte| {
                 _ = write!(output, "{byte:02x}");
                 output
             })
@@ -479,7 +521,7 @@ mod tests {
 
     #[test]
     fn display() {
-        let f = Frame::message("hi there".into(), OpCode::Data(Data::Text), true);
+        let f = Frame::message("hi there", OpCode::Data(Data::Text), true);
         let view = format!("{f}");
         assert!(view.contains("payload:"));
     }

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -5,6 +5,7 @@ pub mod coding;
 #[allow(clippy::module_inception)]
 mod frame;
 mod mask;
+mod payload;
 
 use crate::{
     error::{CapacityError, Error, Result},
@@ -13,7 +14,10 @@ use crate::{
 use log::*;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 
-pub use self::frame::{CloseFrame, Frame, FrameHeader};
+pub use self::{
+    frame::{CloseFrame, Frame, FrameHeader},
+    payload::Payload,
+};
 
 /// A reader and writer for WebSocket frames.
 #[derive(Debug)]
@@ -196,7 +200,7 @@ impl FrameCodec {
 
         let (header, length) = self.header.take().expect("Bug: no frame header");
         debug_assert_eq!(payload.len() as u64, length);
-        let frame = Frame::from_payload(header, payload);
+        let frame = Frame::from_payload(header, payload.into());
         trace!("received frame {frame}");
         Ok(Some(frame))
     }

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -34,8 +34,10 @@ impl Payload {
                 // `Bytes::into()` would not make a copy if our `Bytes` instance is the only one.
                 let data = mem::take(v).into();
                 *self = Payload::Owned(data);
-                let Payload::Owned(v) = self else { unreachable!() };
-                v
+                match self {
+                    Payload::Owned(v) => v,
+                    Payload::Shared(_) => unreachable!(),
+                }
             }
         }
     }

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -43,6 +43,7 @@ impl Payload {
     }
 
     /// Returns the length of the payload.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.as_slice().len()
     }

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -1,0 +1,93 @@
+use std::{mem, string::FromUtf8Error};
+
+use bytes::Bytes;
+
+/// A payload of a WebSocket frame.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Payload {
+    /// Owned data with unique ownership.
+    Owned(Vec<u8>),
+    /// Shared data with shared ownership.
+    Shared(Bytes),
+}
+
+impl Payload {
+    /// Returns a slice of the payload.
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            Payload::Owned(v) => v,
+            Payload::Shared(v) => v,
+        }
+    }
+
+    /// Returns a mutable slice of the payload.
+    ///
+    /// Note that this will internally allocate if the payload is shared
+    /// and there are other references to the same data. No allocation
+    /// would happen if the payload is owned or if there is only one
+    /// `Bytes` instance referencing the data.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        match self {
+            Payload::Owned(v) => &mut *v,
+            Payload::Shared(v) => {
+                // Using `Bytes::to_vec()` or `Vec::from(bytes.as_ref())` would mean making a copy.
+                // `Bytes::into()` would not make a copy if our `Bytes` instance is the only one.
+                let data = mem::take(v).into();
+                *self = Payload::Owned(data);
+                let Payload::Owned(v) = self else { unreachable!() };
+                v
+            }
+        }
+    }
+
+    /// Returns the length of the payload.
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    /// Consumes the payload and returns the underlying data as a vector.
+    pub fn into_data(self) -> Vec<u8> {
+        match self {
+            Payload::Owned(v) => v,
+            Payload::Shared(v) => v.into(),
+        }
+    }
+
+    /// Consumes the payload and returns the underlying data as a string.
+    pub fn into_text(self) -> Result<String, FromUtf8Error> {
+        match self {
+            Payload::Owned(v) => Ok(String::from_utf8(v)?),
+            Payload::Shared(v) => Ok(String::from_utf8(v.into())?),
+        }
+    }
+}
+
+impl From<Vec<u8>> for Payload {
+    fn from(v: Vec<u8>) -> Self {
+        Payload::Owned(v)
+    }
+}
+
+impl From<String> for Payload {
+    fn from(v: String) -> Self {
+        Payload::Owned(v.into_bytes())
+    }
+}
+
+impl From<Bytes> for Payload {
+    fn from(v: Bytes) -> Self {
+        Payload::Shared(v)
+    }
+}
+
+impl From<&'static [u8]> for Payload {
+    fn from(v: &'static [u8]) -> Self {
+        Payload::Shared(Bytes::from_static(v))
+    }
+}
+
+impl From<&'static str> for Payload {
+    fn from(v: &'static str) -> Self {
+        Payload::Shared(Bytes::from_static(v.as_bytes()))
+    }
+}

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -13,6 +13,7 @@ pub enum Payload {
 
 impl Payload {
     /// Returns a slice of the payload.
+    #[inline]
     pub fn as_slice(&self) -> &[u8] {
         match self {
             Payload::Owned(v) => v,
@@ -26,6 +27,7 @@ impl Payload {
     /// and there are other references to the same data. No allocation
     /// would happen if the payload is owned or if there is only one
     /// `Bytes` instance referencing the data.
+    #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         match self {
             Payload::Owned(v) => &mut *v,
@@ -43,12 +45,14 @@ impl Payload {
     }
 
     /// Returns the length of the payload.
+    #[inline]
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.as_slice().len()
     }
 
     /// Consumes the payload and returns the underlying data as a vector.
+    #[inline]
     pub fn into_data(self) -> Vec<u8> {
         match self {
             Payload::Owned(v) => v,
@@ -57,6 +61,7 @@ impl Payload {
     }
 
     /// Consumes the payload and returns the underlying data as a string.
+    #[inline]
     pub fn into_text(self) -> Result<String, FromUtf8Error> {
         match self {
             Payload::Owned(v) => Ok(String::from_utf8(v)?),
@@ -73,7 +78,7 @@ impl From<Vec<u8>> for Payload {
 
 impl From<String> for Payload {
     fn from(v: String) -> Self {
-        Payload::Owned(v.into_bytes())
+        Payload::Owned(v.into())
     }
 }
 

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -284,7 +284,8 @@ impl<'s> From<&'s str> for Message {
 
 impl<'b> From<&'b [u8]> for Message {
     fn from(data: &'b [u8]) -> Self {
-        Message::binary(data.to_vec())
+        let data: Vec<u8> = data.into();
+        Message::binary(data)
     }
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -439,7 +439,7 @@ impl WebSocketContext {
         }
 
         let frame = match message {
-            Message::Text(data) => Frame::message(data.into(), OpCode::Data(OpData::Text), true),
+            Message::Text(data) => Frame::message(data, OpCode::Data(OpData::Text), true),
             Message::Binary(data) => Frame::message(data, OpCode::Data(OpData::Binary), true),
             Message::Ping(data) => Frame::ping(data),
             Message::Pong(data) => {
@@ -608,9 +608,9 @@ impl WebSocketContext {
                             if self.state.is_active() {
                                 self.set_additional(Frame::pong(data.clone()));
                             }
-                            Ok(Some(Message::Ping(data)))
+                            Ok(Some(Message::Ping(data.into())))
                         }
-                        OpCtl::Pong => Ok(Some(Message::Pong(frame.into_data()))),
+                        OpCtl::Pong => Ok(Some(Message::Pong(frame.into_data().into()))),
                     }
                 }
 
@@ -826,10 +826,10 @@ mod tests {
             0x03,
         ]);
         let mut socket = WebSocket::from_raw_socket(WriteMoc(incoming), Role::Client, None);
-        assert_eq!(socket.read().unwrap(), Message::Ping(vec![1, 2]));
-        assert_eq!(socket.read().unwrap(), Message::Pong(vec![3]));
+        assert_eq!(socket.read().unwrap(), Message::Ping(vec![1, 2].into()));
+        assert_eq!(socket.read().unwrap(), Message::Pong(vec![3].into()));
         assert_eq!(socket.read().unwrap(), Message::Text("Hello, World!".into()));
-        assert_eq!(socket.read().unwrap(), Message::Binary(vec![0x01, 0x02, 0x03]));
+        assert_eq!(socket.read().unwrap(), Message::Binary(vec![0x01, 0x02, 0x03].into()));
     }
 
     #[test]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -610,7 +610,7 @@ impl WebSocketContext {
                             }
                             Ok(Some(Message::Ping(data.into())))
                         }
-                        OpCtl::Pong => Ok(Some(Message::Pong(frame.into_data().into()))),
+                        OpCtl::Pong => Ok(Some(Message::Pong(frame.into_payload()))),
                     }
                 }
 


### PR DESCRIPTION
### Preface

Recently, there [has been another PR](https://github.com/snapview/tungstenite-rs/pull/461) trying to solve the long-standing https://github.com/snapview/tungstenite-rs/issues/96.

The issue [had already been addressed in another PR that has been there for a while](https://github.com/snapview/tungstenite-rs/pull/175). I've noticed that I even approved the PR a while ago. Yet, it has not been merged for reasons I can't remember (AFAIR, I was waiting for another approval from another maintainer(s)/active users, but somehow it went stalled). Now, the discussions on the PR and the issue are so long that it's hard to get a brief overview of the current state and blockers, if any.

Yesterday, I quickly went through https://github.com/snapview/tungstenite-rs/pull/175 and the discussions on the issue to see if I could come up with something that would give it at least some resolution (https://github.com/snapview/tungstenite-rs/pull/175 has conflicts with a master branch) and create a small and easy-to-review PR to see if it's something that we can merge rather quickly.

### TL;DR

~~Essentially, the only thing this one changes is that all binary messages are backed by `Bytes` instead of a `Vec<u8>`. The distinction between `Owned` and `Shared` is internal and invisible to the end user.~~ (see https://github.com/snapview/tungstenite-rs/pull/462#issuecomment-2536226200). I also have not touched the text messages for now (as there have been several proposals, and I'm not sure there is a consensus as to which one is the best).

~~So the question is if we are good with having `Bytes` instead of a `Vec<u8>` or if we want to expose that `Payload` type and make `Message` rely on it (like in #175). If I'm not mistaken, the cost of `Bytes` is negligible~~ (see https://github.com/snapview/tungstenite-rs/pull/462#issuecomment-2536226200); the main concern for using `Bytes` as the type for the `Message::Binary` was the additional allocation/copy of a buffer that is done before applying a mask (since `Bytes` is immutable), and #175 did so by creating a copy before applying a mask. I changed it so we don't make this copy if `Bytes` has unique access.

Does it make any sense, or did I miss something?

---

@Dushistov, @sdroege, @francois-random: I decided to mention you folks since you participated in the discussion the most in the past year and seem interested in the outcome of this one. I'm going to also mention @alexheretic (you seem to be interested in performance-related improvements 🙂).


-- 

Fixes https://github.com/snapview/tungstenite-rs/issues/96
Supersedes https://github.com/snapview/tungstenite-rs/pull/175 if we agree that it's a sensible solution.