### PR TITLE
Add 100k read benchmark & client/server bench variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,12 +70,19 @@ input_buffer = "0.5.0"
 rand = "0.8.4"
 socket2 = "0.5.5"
 
+[profile.bench]
+lto = "thin"
+
 [[bench]]
 name = "buffer"
 harness = false
 
 [[bench]]
 name = "write"
+harness = false
+
+[[bench]]
+name = "read"
 harness = false
 
 [[example]]

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -1,0 +1,92 @@
+//! Benchmarks for read performance.
+use criterion::{BatchSize, Criterion};
+use std::{
+    io::{self, Read, Write},
+    sync::{Arc, Mutex},
+};
+use tungstenite::{protocol::Role, Message, WebSocket};
+
+/// Mock stream with no artificial delays.
+#[derive(Default, Clone)]
+struct MockIo(Arc<Mutex<Vec<u8>>>);
+
+impl Read for MockIo {
+    fn read(&mut self, to: &mut [u8]) -> io::Result<usize> {
+        let mut data = self.0.lock().unwrap();
+        if data.is_empty() {
+            return Err(io::Error::new(io::ErrorKind::WouldBlock, "not ready"));
+        }
+        let len = data.len().min(to.len());
+        to[..len].copy_from_slice(data.drain(..len).as_slice());
+        Ok(len)
+    }
+}
+
+impl Write for MockIo {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn benchmark(c: &mut Criterion) {
+    /// Benchmark reading 100k mix of binary & text messages.
+    fn read_100k(role: Role, b: &mut criterion::Bencher<'_>) {
+        let io = MockIo::default();
+        let mut writer = WebSocket::from_raw_socket(
+            io.clone(),
+            match role {
+                Role::Client => Role::Server,
+                Role::Server => Role::Client,
+            },
+            None,
+        );
+        let mut ws = WebSocket::from_raw_socket(io, role, None);
+
+        b.iter_batched(
+            || {
+                let mut sum = 0;
+                for i in 0_u64..100_000 {
+                    writer
+                        .send(match i {
+                            _ if i % 3 == 0 => Message::Binary(i.to_le_bytes().into()),
+                            _ => Message::Text(format!("{{\"id\":{i}}}")),
+                        })
+                        .unwrap();
+                    sum += i;
+                }
+                sum
+            },
+            |expected_sum| {
+                let mut sum = 0;
+                while sum != expected_sum {
+                    match ws.read().unwrap() {
+                        Message::Binary(v) => {
+                            let a: &[u8; 8] = v.as_slice().try_into().unwrap();
+                            sum += u64::from_le_bytes(*a);
+                        }
+                        Message::Text(msg) => {
+                            let i: u64 = msg[6..msg.len() - 1].parse().unwrap();
+                            sum += i;
+                        }
+                        m => panic!("Unexpected {m}"),
+                    }
+                }
+            },
+            BatchSize::SmallInput,
+        );
+    }
+
+    c.bench_function("read+unmask 100k small messages (server)", |b| {
+        read_100k(Role::Server, b);
+    });
+
+    c.bench_function("read 100k small messages (client)", |b| {
+        read_100k(Role::Client, b);
+    });
+}
+
+criterion::criterion_group!(read_benches, benchmark);
+criterion::criterion_main!(read_benches);


### PR DESCRIPTION
Expand the write bench to have server & client variants and include a mix of binary & text messages to more broadly reflect overall performance.

Add a new "read" bench to similarly bench read performance of client & server.

```
read+unmask 100k small messages (server)
                        time:   [14.817 ms 15.173 ms 15.262 ms]

read 100k small messages (client)
                        time:   [11.017 ms 11.079 ms 11.324 ms]

write 100k small messages then flush (server)
                        time:   [3.7303 ms 3.7398 ms 3.7779 ms]

write+mask 100k small messages then flush (client)
                        time:   [5.2197 ms 5.2263 ms 5.2279 ms]
```