### PR TITLE
Bench: optimise binary data generation

### DIFF
--- a/benches/read.rs
+++ b/benches/read.rs
@@ -51,7 +51,7 @@ fn benchmark(c: &mut Criterion) {
                 for i in 0_u64..100_000 {
                     writer
                         .send(match i {
-                            _ if i % 3 == 0 => Message::Binary(i.to_le_bytes().into()),
+                            _ if i % 3 == 0 => Message::binary(i.to_le_bytes().to_vec()),
                             _ => Message::Text(format!("{{\"id\":{i}}}")),
                         })
                         .unwrap();

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -57,7 +57,7 @@ fn benchmark(c: &mut Criterion) {
         b.iter(|| {
             for i in 0_u64..100_000 {
                 let msg = match i {
-                    _ if i % 3 == 0 => Message::Binary(i.to_le_bytes().into()),
+                    _ if i % 3 == 0 => Message::binary(i.to_le_bytes().to_vec()),
                     _ => Message::Text(format!("{{\"id\":{i}}}")),
                 };
                 ws.write(msg).unwrap();


### PR DESCRIPTION
I noticed `slice::to_vec` seems to be faster than `.into()` :shrug:. This code is also more compatible with the proposed approach in #462 

As this generates vec data faster it makes the bench faster (but just the bench) .

```
write 100k small messages then flush (server)
                        time:   [4.0320 ms 4.0390 ms 4.0672 ms]
                        change: [-8.8302% -8.3994% -7.9684%] (p = 0.05 > 0.05)

write+mask 100k small messages then flush (client)
                        time:   [5.3872 ms 5.3921 ms 5.4115 ms]
                        change: [-8.0997% -7.6006% -7.0983%] (p = 0.07 > 0.05)
```