### PR TITLE
Support `bytes::Bytes` & `bytes::BytesMut` payloads for binary & text messaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ __rustls-tls = ["rustls", "rustls-pki-types"]
 [dependencies]
 data-encoding = { version = "2", optional = true }
 byteorder = "1.3.2"
-bytes = "1.0"
+bytes = "1.9.0"
 http = { version = "1.0", optional = true }
 httparse = { version = "1.3.4", optional = true }
 log = "0.4.8"

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -52,7 +52,7 @@ fn benchmark(c: &mut Criterion) {
                     writer
                         .send(match i {
                             _ if i % 3 == 0 => Message::binary(i.to_le_bytes().to_vec()),
-                            _ => Message::Text(format!("{{\"id\":{i}}}")),
+                            _ => Message::text(format!("{{\"id\":{i}}}")),
                         })
                         .unwrap();
                     sum += i;
@@ -68,7 +68,7 @@ fn benchmark(c: &mut Criterion) {
                             sum += u64::from_le_bytes(*a);
                         }
                         Message::Text(msg) => {
-                            let i: u64 = msg[6..msg.len() - 1].parse().unwrap();
+                            let i: u64 = msg.as_str()[6..msg.len() - 1].parse().unwrap();
                             sum += i;
                         }
                         m => panic!("Unexpected {m}"),

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -58,7 +58,7 @@ fn benchmark(c: &mut Criterion) {
             for i in 0_u64..100_000 {
                 let msg = match i {
                     _ if i % 3 == 0 => Message::binary(i.to_le_bytes().to_vec()),
-                    _ => Message::Text(format!("{{\"id\":{i}}}")),
+                    _ => Message::text(format!("{{\"id\":{i}}}")),
                 };
                 ws.write(msg).unwrap();
             }

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -1,8 +1,6 @@
 //! Benchmarks for write performance.
-use bytes::{BufMut, BytesMut};
 use criterion::Criterion;
 use std::{
-    fmt::Write as _,
     hint, io,
     time::{Duration, Instant},
 };
@@ -55,19 +53,11 @@ fn benchmark(c: &mut Criterion) {
         let mut ws =
             WebSocket::from_raw_socket(MockWrite(Vec::with_capacity(MOCK_WRITE_LEN)), role, None);
 
-        let mut buf = BytesMut::with_capacity(128 * 1024);
-
         b.iter(|| {
             for i in 0_u64..100_000 {
                 let msg = match i {
-                    _ if i % 3 == 0 => {
-                        buf.put_slice(&i.to_le_bytes());
-                        Message::binary(buf.split())
-                    }
-                    _ => {
-                        buf.write_fmt(format_args!("{{\"id\":{i}}}")).unwrap();
-                        Message::Text(buf.split().try_into().unwrap())
-                    }
+                    _ if i % 3 == 0 => Message::binary(i.to_le_bytes().to_vec()),
+                    _ => Message::text(format!("{{\"id\":{i}}}")),
                 };
                 ws.write(msg).unwrap();
             }

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -8,7 +8,7 @@ fn get_case_count() -> Result<u32> {
     let (mut socket, _) = connect("ws://localhost:9001/getCaseCount")?;
     let msg = socket.read()?;
     socket.close(None)?;
-    Ok(msg.into_text()?.parse::<u32>().unwrap())
+    Ok(msg.into_text()?.as_str().parse::<u32>().unwrap())
 }
 
 fn update_reports() -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Lightweight, flexible WebSockets for Rust.
 #![deny(
-    // missing_docs,
+    missing_docs,
     missing_copy_implementations,
     missing_debug_implementations,
     trivial_casts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Lightweight, flexible WebSockets for Rust.
 #![deny(
-    missing_docs,
+    // missing_docs,
     missing_copy_implementations,
     missing_debug_implementations,
     trivial_casts,

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -1,14 +1,17 @@
-use byteorder::{NetworkEndian, ReadBytesExt};
-use log::*;
 use std::{
     borrow::Cow,
     default::Default,
     fmt,
     io::{Cursor, ErrorKind, Read, Write},
+    mem,
     result::Result as StdResult,
     str::Utf8Error,
     string::{FromUtf8Error, String},
 };
+
+use byteorder::{NetworkEndian, ReadBytesExt};
+use bytes::Bytes;
+use log::*;
 
 use super::{
     coding::{CloseCode, Control, Data, OpCode},
@@ -203,11 +206,47 @@ impl FrameHeader {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum Payload {
+    Owned(Vec<u8>),
+    Shared(Bytes),
+}
+
+impl Payload {
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            Payload::Owned(v) => v,
+            Payload::Shared(v) => v,
+        }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        match self {
+            Payload::Owned(v) => &mut *v,
+            Payload::Shared(v) => {
+                // Using `Bytes::to_vec()` or `Vec::from(bytes.as_ref())` would mean making a copy.
+                // `Bytes::into()` would not make a copy if our `Bytes` instance is the only one.
+                let data = mem::take(v).into();
+                *self = Payload::Owned(data);
+                let Payload::Owned(v) = self else { unreachable!() };
+                v
+            }
+        }
+    }
+
+    pub fn into_data(self) -> Vec<u8> {
+        match self {
+            Payload::Owned(v) => v,
+            Payload::Shared(v) => v.into(),
+        }
+    }
+}
+
 /// A struct representing a WebSocket frame.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Frame {
     header: FrameHeader,
-    payload: Vec<u8>,
+    payload: Payload,
 }
 
 impl Frame {
@@ -215,7 +254,7 @@ impl Frame {
     /// This is the length of the header + the length of the payload.
     #[inline]
     pub fn len(&self) -> usize {
-        let length = self.payload.len();
+        let length = self.payload.as_slice().len();
         self.header.len(length as u64) + length
     }
 
@@ -239,14 +278,14 @@ impl Frame {
 
     /// Get a reference to the frame's payload.
     #[inline]
-    pub fn payload(&self) -> &Vec<u8> {
-        &self.payload
+    pub fn payload(&self) -> &[u8] {
+        self.payload.as_slice()
     }
 
     /// Get a mutable reference to the frame's payload.
     #[inline]
-    pub fn payload_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.payload
+    pub fn payload_mut(&mut self) -> &mut [u8] {
+        self.payload.as_mut_slice()
     }
 
     /// Test whether the frame is masked.
@@ -269,36 +308,36 @@ impl Frame {
     #[inline]
     pub(crate) fn apply_mask(&mut self) {
         if let Some(mask) = self.header.mask.take() {
-            apply_mask(&mut self.payload, mask);
+            apply_mask(self.payload.as_mut_slice(), mask);
         }
     }
 
     /// Consume the frame into its payload as binary.
     #[inline]
     pub fn into_data(self) -> Vec<u8> {
-        self.payload
+        self.payload.into_data()
     }
 
     /// Consume the frame into its payload as string.
     #[inline]
     pub fn into_string(self) -> StdResult<String, FromUtf8Error> {
-        String::from_utf8(self.payload)
+        String::from_utf8(self.payload.into_data())
     }
 
     /// Get frame payload as `&str`.
     #[inline]
     pub fn to_text(&self) -> Result<&str, Utf8Error> {
-        std::str::from_utf8(&self.payload)
+        std::str::from_utf8(self.payload.as_slice())
     }
 
     /// Consume the frame into a closing frame.
     #[inline]
     pub(crate) fn into_close(self) -> Result<Option<CloseFrame<'static>>> {
-        match self.payload.len() {
+        match self.payload.as_slice().len() {
             0 => Ok(None),
             1 => Err(Error::Protocol(ProtocolError::InvalidCloseSequence)),
             _ => {
-                let mut data = self.payload;
+                let mut data = self.payload.into_data();
                 let code = u16::from_be_bytes([data[0], data[1]]).into();
                 data.drain(0..2);
                 let text = String::from_utf8(data)?;
@@ -309,33 +348,36 @@ impl Frame {
 
     /// Create a new data frame.
     #[inline]
-    pub fn message(data: Vec<u8>, opcode: OpCode, is_final: bool) -> Frame {
+    pub fn message(data: impl Into<Bytes>, opcode: OpCode, is_final: bool) -> Frame {
         debug_assert!(matches!(opcode, OpCode::Data(_)), "Invalid opcode for data frame.");
 
-        Frame { header: FrameHeader { is_final, opcode, ..FrameHeader::default() }, payload: data }
+        Frame {
+            header: FrameHeader { is_final, opcode, ..FrameHeader::default() },
+            payload: Payload::Shared(data.into()),
+        }
     }
 
     /// Create a new Pong control frame.
     #[inline]
-    pub fn pong(data: Vec<u8>) -> Frame {
+    pub fn pong(data: impl Into<Bytes>) -> Frame {
         Frame {
             header: FrameHeader {
                 opcode: OpCode::Control(Control::Pong),
                 ..FrameHeader::default()
             },
-            payload: data,
+            payload: Payload::Shared(data.into()),
         }
     }
 
     /// Create a new Ping control frame.
     #[inline]
-    pub fn ping(data: Vec<u8>) -> Frame {
+    pub fn ping(data: impl Into<Bytes>) -> Frame {
         Frame {
             header: FrameHeader {
                 opcode: OpCode::Control(Control::Ping),
                 ..FrameHeader::default()
             },
-            payload: data,
+            payload: Payload::Shared(data.into()),
         }
     }
 
@@ -351,17 +393,17 @@ impl Frame {
             Vec::new()
         };
 
-        Frame { header: FrameHeader::default(), payload }
+        Frame { header: FrameHeader::default(), payload: Payload::Owned(payload) }
     }
 
     /// Create a frame from given header and data.
-    pub fn from_payload(header: FrameHeader, payload: Vec<u8>) -> Self {
-        Frame { header, payload }
+    pub fn from_payload(header: FrameHeader, payload: impl Into<Bytes>) -> Self {
+        Frame { header, payload: Payload::Shared(payload.into()) }
     }
 
     /// Write a frame out to a buffer
     pub fn format(mut self, output: &mut impl Write) -> Result<()> {
-        self.header.format(self.payload.len() as u64, output)?;
+        self.header.format(self.payload.as_slice().len() as u64, output)?;
         self.apply_mask();
         output.write_all(self.payload())?;
         Ok(())
@@ -390,8 +432,8 @@ payload: 0x{}
             self.header.opcode,
             // self.mask.map(|mask| format!("{:?}", mask)).unwrap_or("NONE".into()),
             self.len(),
-            self.payload.len(),
-            self.payload.iter().fold(String::new(), |mut output, byte| {
+            self.payload.as_slice().len(),
+            self.payload.as_slice().iter().fold(String::new(), |mut output, byte| {
                 _ = write!(output, "{byte:02x}");
                 output
             })
@@ -479,7 +521,7 @@ mod tests {
 
     #[test]
     fn display() {
-        let f = Frame::message("hi there".into(), OpCode::Data(Data::Text), true);
+        let f = Frame::message("hi there", OpCode::Data(Data::Text), true);
         let view = format!("{f}");
         assert!(view.contains("payload:"));
     }

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -304,7 +304,7 @@ impl Frame {
             0 => Ok(None),
             1 => Err(Error::Protocol(ProtocolError::InvalidCloseSequence)),
             _ => {
-                let mut data = self.payload.into_data();
+                let mut data = self.payload.as_slice();
                 let code = u16::from_be_bytes([data[0], data[1]]).into();
                 data.advance(2);
                 let text = String::from_utf8(data.to_vec())?;

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -209,7 +209,7 @@ impl FrameHeader {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Frame {
     header: FrameHeader,
-    payload: Payload,
+    pub(crate) payload: Payload,
 }
 
 impl Frame {

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -185,7 +185,7 @@ impl FrameCodec {
                     }
 
                     if len <= self.in_buffer.len() {
-                        break self.in_buffer.split_to(len).freeze();
+                        break self.in_buffer.split_to(len);
                     }
                 }
             }
@@ -206,7 +206,7 @@ impl FrameCodec {
 
         let (header, length) = self.header.take().expect("Bug: no frame header");
         debug_assert_eq!(payload.len() as u64, length);
-        let frame = Frame::from_payload(header, payload.into());
+        let frame = Frame::from_payload(header, Payload::Owned(payload));
         trace!("received frame {frame}");
         Ok(Some(frame))
     }
@@ -282,10 +282,13 @@ mod tests {
         let mut sock = FrameSocket::new(raw);
 
         assert_eq!(
-            sock.read(None).unwrap().unwrap().into_data(),
-            vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+            sock.read(None).unwrap().unwrap().into_payload().as_slice(),
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
         );
-        assert_eq!(sock.read(None).unwrap().unwrap().into_data(), vec![0x03, 0x02, 0x01]);
+        assert_eq!(
+            sock.read(None).unwrap().unwrap().into_payload().as_slice(),
+            &[0x03, 0x02, 0x01]
+        );
         assert!(sock.read(None).unwrap().is_none());
 
         let (_, rest) = sock.into_inner();
@@ -297,8 +300,8 @@ mod tests {
         let raw = Cursor::new(vec![0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
         let mut sock = FrameSocket::from_partially_read(raw, vec![0x82, 0x07, 0x01]);
         assert_eq!(
-            sock.read(None).unwrap().unwrap().into_data(),
-            vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+            sock.read(None).unwrap().unwrap().into_payload().as_slice(),
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
         );
     }
 

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -121,7 +121,7 @@ impl FrameCodec {
     pub(super) fn new() -> Self {
         Self {
             in_buffer: BytesMut::with_capacity(READ_BUFFER_CAP),
-            out_buffer: Vec::new(),
+            out_buffer: <_>::default(),
             max_out_buffer_len: usize::MAX,
             out_buffer_write_len: 0,
             header: None,
@@ -134,7 +134,7 @@ impl FrameCodec {
         in_buffer.reserve(READ_BUFFER_CAP.saturating_sub(in_buffer.len()));
         Self {
             in_buffer,
-            out_buffer: Vec::new(),
+            out_buffer: <_>::default(),
             max_out_buffer_len: usize::MAX,
             out_buffer_write_len: 0,
             header: None,

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -5,6 +5,7 @@ pub mod coding;
 #[allow(clippy::module_inception)]
 mod frame;
 mod mask;
+mod payload;
 
 use crate::{
     error::{CapacityError, Error, Result},
@@ -13,7 +14,10 @@ use crate::{
 use log::*;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 
-pub use self::frame::{CloseFrame, Frame, FrameHeader};
+pub use self::{
+    frame::{CloseFrame, Frame, FrameHeader},
+    payload::Payload,
+};
 
 /// A reader and writer for WebSocket frames.
 #[derive(Debug)]
@@ -196,7 +200,7 @@ impl FrameCodec {
 
         let (header, length) = self.header.take().expect("Bug: no frame header");
         debug_assert_eq!(payload.len() as u64, length);
-        let frame = Frame::from_payload(header, payload);
+        let frame = Frame::from_payload(header, payload.into());
         trace!("received frame {frame}");
         Ok(Some(frame))
     }

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -34,8 +34,10 @@ impl Payload {
                 // `Bytes::into()` would not make a copy if our `Bytes` instance is the only one.
                 let data = mem::take(v).into();
                 *self = Payload::Owned(data);
-                let Payload::Owned(v) = self else { unreachable!() };
-                v
+                match self {
+                    Payload::Owned(v) => v,
+                    Payload::Shared(_) => unreachable!(),
+                }
             }
         }
     }

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -1,9 +1,87 @@
-use std::{mem, string::FromUtf8Error};
+use std::{fmt::Display, mem, string::FromUtf8Error};
 
 use bytes::Bytes;
+use core::str;
+
+/// Utf8 payload.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct Utf8Payload(Payload);
+
+impl Utf8Payload {
+    #[inline]
+    pub const fn from_static(str: &'static str) -> Self {
+        Self(Payload::Shared(Bytes::from_static(str.as_bytes())))
+    }
+
+    /// Returns a slice of the payload.
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        // safety: is valid uft8
+        unsafe { str::from_utf8_unchecked(self.as_slice()) }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl TryFrom<Payload> for Utf8Payload {
+    type Error = str::Utf8Error;
+
+    #[inline]
+    fn try_from(payload: Payload) -> Result<Self, Self::Error> {
+        str::from_utf8(payload.as_slice())?;
+        Ok(Self(payload))
+    }
+}
+
+impl From<String> for Utf8Payload {
+    #[inline]
+    fn from(s: String) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<&str> for Utf8Payload {
+    #[inline]
+    fn from(s: &str) -> Self {
+        Self(Payload::Owned(s.as_bytes().to_vec()))
+    }
+}
+
+impl From<&String> for Utf8Payload {
+    #[inline]
+    fn from(s: &String) -> Self {
+        s.as_str().into()
+    }
+}
+
+impl From<Utf8Payload> for Payload {
+    #[inline]
+    fn from(Utf8Payload(payload): Utf8Payload) -> Self {
+        payload
+    }
+}
+
+impl Display for Utf8Payload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// A payload of a WebSocket frame.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum Payload {
     /// Owned data with unique ownership.
     Owned(Vec<u8>),
@@ -12,6 +90,19 @@ pub enum Payload {
 }
 
 impl Payload {
+    #[inline]
+    pub const fn from_static(bytes: &'static [u8]) -> Self {
+        Self::Shared(Bytes::from_static(bytes))
+    }
+
+    #[inline]
+    pub fn from_owner<T>(owner: T) -> Self
+    where
+        T: AsRef<[u8]> + Send + 'static,
+    {
+        Self::Shared(Bytes::from_owner(owner))
+    }
+
     /// Returns a slice of the payload.
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
@@ -70,32 +161,67 @@ impl Payload {
     }
 }
 
+impl Default for Payload {
+    #[inline]
+    fn default() -> Self {
+        Self::Owned(Vec::new())
+    }
+}
+
 impl From<Vec<u8>> for Payload {
+    #[inline]
     fn from(v: Vec<u8>) -> Self {
         Payload::Owned(v)
     }
 }
 
 impl From<String> for Payload {
+    #[inline]
     fn from(v: String) -> Self {
         Payload::Owned(v.into())
     }
 }
 
 impl From<Bytes> for Payload {
+    #[inline]
     fn from(v: Bytes) -> Self {
         Payload::Shared(v)
     }
 }
 
 impl From<&'static [u8]> for Payload {
+    #[inline]
     fn from(v: &'static [u8]) -> Self {
-        Payload::Shared(Bytes::from_static(v))
+        Self::from_static(v)
     }
 }
 
 impl From<&'static str> for Payload {
+    #[inline]
     fn from(v: &'static str) -> Self {
-        Payload::Shared(Bytes::from_static(v.as_bytes()))
+        Self::from_static(v.as_bytes())
+    }
+}
+
+impl PartialEq<Payload> for Payload {
+    #[inline]
+    fn eq(&self, other: &Payload) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for Payload {}
+
+impl PartialEq<[u8]> for Payload {
+    #[inline]
+    fn eq(&self, other: &[u8]) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl<const N: usize> PartialEq<&[u8; N]> for Payload {
+    #[inline]
+    fn eq(&self, other: &&[u8; N]) -> bool {
+        self.as_slice() == *other
     }
 }

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -43,6 +43,7 @@ impl Payload {
     }
 
     /// Returns the length of the payload.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.as_slice().len()
     }

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -7,6 +7,7 @@ use std::{fmt::Display, mem};
 pub struct Utf8Payload(Payload);
 
 impl Utf8Payload {
+    /// Creates from a static str.
     #[inline]
     pub const fn from_static(str: &'static str) -> Self {
         Self(Payload::Shared(Bytes::from_static(str.as_bytes())))
@@ -18,17 +19,20 @@ impl Utf8Payload {
         self.0.as_slice()
     }
 
+    /// Returns as a string slice.
     #[inline]
     pub fn as_str(&self) -> &str {
         // safety: is valid uft8
         unsafe { str::from_utf8_unchecked(self.as_slice()) }
     }
 
+    /// Returns length in bytes.
     #[inline]
     pub fn len(&self) -> usize {
         self.as_slice().len()
     }
 
+    /// Returns true if the length is 0.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -124,17 +128,10 @@ pub enum Payload {
 }
 
 impl Payload {
+    /// Creates from static bytes.
     #[inline]
     pub const fn from_static(bytes: &'static [u8]) -> Self {
         Self::Shared(Bytes::from_static(bytes))
-    }
-
-    #[inline]
-    pub fn from_owner<T>(owner: T) -> Self
-    where
-        T: AsRef<[u8]> + Send + 'static,
-    {
-        Self::Shared(Bytes::from_owner(owner))
     }
 
     /// Converts into [`Bytes`] internals & then clones (cheaply).

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -1,0 +1,93 @@
+use std::{mem, string::FromUtf8Error};
+
+use bytes::Bytes;
+
+/// A payload of a WebSocket frame.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Payload {
+    /// Owned data with unique ownership.
+    Owned(Vec<u8>),
+    /// Shared data with shared ownership.
+    Shared(Bytes),
+}
+
+impl Payload {
+    /// Returns a slice of the payload.
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            Payload::Owned(v) => v,
+            Payload::Shared(v) => v,
+        }
+    }
+
+    /// Returns a mutable slice of the payload.
+    ///
+    /// Note that this will internally allocate if the payload is shared
+    /// and there are other references to the same data. No allocation
+    /// would happen if the payload is owned or if there is only one
+    /// `Bytes` instance referencing the data.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        match self {
+            Payload::Owned(v) => &mut *v,
+            Payload::Shared(v) => {
+                // Using `Bytes::to_vec()` or `Vec::from(bytes.as_ref())` would mean making a copy.
+                // `Bytes::into()` would not make a copy if our `Bytes` instance is the only one.
+                let data = mem::take(v).into();
+                *self = Payload::Owned(data);
+                let Payload::Owned(v) = self else { unreachable!() };
+                v
+            }
+        }
+    }
+
+    /// Returns the length of the payload.
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    /// Consumes the payload and returns the underlying data as a vector.
+    pub fn into_data(self) -> Vec<u8> {
+        match self {
+            Payload::Owned(v) => v,
+            Payload::Shared(v) => v.into(),
+        }
+    }
+
+    /// Consumes the payload and returns the underlying data as a string.
+    pub fn into_text(self) -> Result<String, FromUtf8Error> {
+        match self {
+            Payload::Owned(v) => Ok(String::from_utf8(v)?),
+            Payload::Shared(v) => Ok(String::from_utf8(v.into())?),
+        }
+    }
+}
+
+impl From<Vec<u8>> for Payload {
+    fn from(v: Vec<u8>) -> Self {
+        Payload::Owned(v)
+    }
+}
+
+impl From<String> for Payload {
+    fn from(v: String) -> Self {
+        Payload::Owned(v.into_bytes())
+    }
+}
+
+impl From<Bytes> for Payload {
+    fn from(v: Bytes) -> Self {
+        Payload::Shared(v)
+    }
+}
+
+impl From<&'static [u8]> for Payload {
+    fn from(v: &'static [u8]) -> Self {
+        Payload::Shared(Bytes::from_static(v))
+    }
+}
+
+impl From<&'static str> for Payload {
+    fn from(v: &'static str) -> Self {
+        Payload::Shared(Bytes::from_static(v.as_bytes()))
+    }
+}

--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -13,6 +13,7 @@ pub enum Payload {
 
 impl Payload {
     /// Returns a slice of the payload.
+    #[inline]
     pub fn as_slice(&self) -> &[u8] {
         match self {
             Payload::Owned(v) => v,
@@ -26,6 +27,7 @@ impl Payload {
     /// and there are other references to the same data. No allocation
     /// would happen if the payload is owned or if there is only one
     /// `Bytes` instance referencing the data.
+    #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         match self {
             Payload::Owned(v) => &mut *v,
@@ -43,12 +45,14 @@ impl Payload {
     }
 
     /// Returns the length of the payload.
+    #[inline]
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.as_slice().len()
     }
 
     /// Consumes the payload and returns the underlying data as a vector.
+    #[inline]
     pub fn into_data(self) -> Vec<u8> {
         match self {
             Payload::Owned(v) => v,
@@ -57,6 +61,7 @@ impl Payload {
     }
 
     /// Consumes the payload and returns the underlying data as a string.
+    #[inline]
     pub fn into_text(self) -> Result<String, FromUtf8Error> {
         match self {
             Payload::Owned(v) => Ok(String::from_utf8(v)?),
@@ -73,7 +78,7 @@ impl From<Vec<u8>> for Payload {
 
 impl From<String> for Payload {
     fn from(v: String) -> Self {
-        Payload::Owned(v.into_bytes())
+        Payload::Owned(v.into())
     }
 }
 

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -277,43 +277,39 @@ impl Message {
 }
 
 impl From<String> for Message {
+    #[inline]
     fn from(string: String) -> Self {
         Message::text(string)
     }
 }
 
 impl<'s> From<&'s str> for Message {
+    #[inline]
     fn from(string: &'s str) -> Self {
         Message::text(string)
     }
 }
 
 impl<'b> From<&'b [u8]> for Message {
+    #[inline]
     fn from(data: &'b [u8]) -> Self {
-        let data: Vec<u8> = data.into();
         Message::binary(data)
     }
 }
 
 impl From<Vec<u8>> for Message {
+    #[inline]
     fn from(data: Vec<u8>) -> Self {
         Message::binary(data)
     }
 }
 
 impl From<Message> for Vec<u8> {
+    #[inline]
     fn from(message: Message) -> Self {
         message.into_data().as_slice().into()
     }
 }
-
-// impl TryFrom<Message> for String {
-//     type Error = Error;
-
-//     fn try_from(value: Message) -> StdResult<Self, Self::Error> {
-//         Ok(value.into_text()?.as_str().into())
-//     }
-// }
 
 impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -241,7 +241,7 @@ impl Message {
                 Cow::Borrowed(s) => Payload::from_static(s.as_bytes()),
                 Cow::Owned(s) => s.into(),
             },
-            Message::Frame(frame) => frame.payload,
+            Message::Frame(frame) => frame.into_payload(),
         }
     }
 
@@ -257,7 +257,7 @@ impl Message {
                 Cow::Borrowed(s) => Utf8Payload::from_static(s),
                 Cow::Owned(s) => s.into(),
             }),
-            Message::Frame(frame) => Ok(frame.payload.try_into()?),
+            Message::Frame(frame) => Ok(frame.into_text()?),
         }
     }
 

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -284,7 +284,8 @@ impl<'s> From<&'s str> for Message {
 
 impl<'b> From<&'b [u8]> for Message {
     fn from(data: &'b [u8]) -> Self {
-        Message::binary(data.to_vec())
+        let data: Vec<u8> = data.into();
+        Message::binary(data)
     }
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -439,7 +439,7 @@ impl WebSocketContext {
         }
 
         let frame = match message {
-            Message::Text(data) => Frame::message(data.into(), OpCode::Data(OpData::Text), true),
+            Message::Text(data) => Frame::message(data, OpCode::Data(OpData::Text), true),
             Message::Binary(data) => Frame::message(data, OpCode::Data(OpData::Binary), true),
             Message::Ping(data) => Frame::ping(data),
             Message::Pong(data) => {
@@ -608,9 +608,9 @@ impl WebSocketContext {
                             if self.state.is_active() {
                                 self.set_additional(Frame::pong(data.clone()));
                             }
-                            Ok(Some(Message::Ping(data)))
+                            Ok(Some(Message::Ping(data.into())))
                         }
-                        OpCtl::Pong => Ok(Some(Message::Pong(frame.into_data()))),
+                        OpCtl::Pong => Ok(Some(Message::Pong(frame.into_data().into()))),
                     }
                 }
 
@@ -826,10 +826,10 @@ mod tests {
             0x03,
         ]);
         let mut socket = WebSocket::from_raw_socket(WriteMoc(incoming), Role::Client, None);
-        assert_eq!(socket.read().unwrap(), Message::Ping(vec![1, 2]));
-        assert_eq!(socket.read().unwrap(), Message::Pong(vec![3]));
+        assert_eq!(socket.read().unwrap(), Message::Ping(vec![1, 2].into()));
+        assert_eq!(socket.read().unwrap(), Message::Pong(vec![3].into()));
         assert_eq!(socket.read().unwrap(), Message::Text("Hello, World!".into()));
-        assert_eq!(socket.read().unwrap(), Message::Binary(vec![0x01, 0x02, 0x03]));
+        assert_eq!(socket.read().unwrap(), Message::Binary(vec![0x01, 0x02, 0x03].into()));
     }
 
     #[test]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -610,7 +610,7 @@ impl WebSocketContext {
                             }
                             Ok(Some(Message::Ping(data.into())))
                         }
-                        OpCtl::Pong => Ok(Some(Message::Pong(frame.into_data().into()))),
+                        OpCtl::Pong => Ok(Some(Message::Pong(frame.into_payload()))),
                     }
                 }
 


### PR DESCRIPTION
This PR builds on top of #462 
* Adds `Utf8Payload` for text messages backed by `Payload`.
* Tri-variant `Payload` for `Bytes`, `BytesMut` & `Vec`.
  - `Bytes` gives flexibility supporting shared data & cheap cloning.
  - `BytesMut` provides best read performance as we can get these from the new read buffer sans copying & unmask optimially too.
  - `Vec` provides best write performance. I couldn't get `BytesMut` to perform as well even changing the bench user code. Since it doesn't increase Payload 40 bytes size it seems worth having.
* Replace the read buffer with a `BytesMut` based one that can then emit payloads without copying.
* Optimise incomplete message handling so complete messages do not need to be copied (general case for small messages).
* Add `Payload::share` for cheap cloning.
* Make `Payload::eq` compare data, so allow equality across variants.
* Remove and change a bunch of fns & types to suit the new internals.
* Add general &[u8]/&str From impl and use `const fn from_static` to construct static `Payload`/`Utf8Payload` data.

The main advantage here is extending the _bytes_ flexibility to Text types and better read performance.

### Benchmarks
Write performance remains a little slower, no more than [noted in the parent PR](https://github.com/snapview/tungstenite-rs/pull/462#issuecomment-2542530496). However, read performance is significantly faster.
```
$ cargo bench --bench \* -- --quick --noplot --baseline master
read+unmask 100k small messages (server)
                        time:   [7.8768 ms 7.9103 ms 7.9187 ms]
                        change: [-38.736% -37.861% -36.967%] (p = 0.06 > 0.05)

read 100k small messages (client)
                        time:   [7.1168 ms 7.1322 ms 7.1939 ms]
                        change: [-34.273% -33.840% -33.406%] (p = 0.07 > 0.05)

write 100k small messages then flush (server)
                        time:   [4.6548 ms 4.6852 ms 4.6928 ms]
                        change: [+6.0437% +6.5546% +7.0663%] (p = 0.10 > 0.05)

write+mask 100k small messages then flush (client)
                        time:   [6.0834 ms 6.0875 ms 6.1039 ms]
                        change: [+6.0147% +6.6040% +7.1980%] (p = 0.10 > 0.05)
```