### PR TITLE
tiny optimization: use more optimized method for Vec<u8> to Bytes conversation

### DIFF
--- a/src/protocol/frame/payload.rs
+++ b/src/protocol/frame/payload.rs
@@ -141,7 +141,7 @@ impl Payload {
                 *self = Self::Shared(mem::take(data).freeze());
             }
             Self::Vec(data) => {
-                *self = Self::Shared(Bytes::from_owner(mem::take(data)));
+                *self = Self::Shared(Bytes::from(mem::take(data)));
             }
             Self::Shared(_) => {}
         }


### PR DESCRIPTION
Bytes::from_owner is "generic" method, for any "owners" of [u8], while specialized "impl From<Vec<u8>> for Bytes" can be faster in some cases, for example if Vec::capacity==Vec::len, then it is almost no-op.