### PR TITLE
Add `WebSocketConfig::read_buffer_size` default 128 KiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - New `Payload` type for `Message` that allows sending messages with a payload that can be cheaply cloned (`Bytes`).
   Long standing [issue](https://github.com/snapview/tungstenite-rs/issues/96) solved!
+- Add `WebSocketConfig::read_buffer_size` default 128 KiB.
+- Make `WebSocketConfig` non-exhaustive & add builder style construction fns.
+- Remove deprecated `WebSocketConfig::max_send_queue`.
 - Trim spaces on `Sec-WebSocket-Protocol` header.
 
 # 0.24.0

--- a/examples/srv_accept_unmasked_frames.rs
+++ b/examples/srv_accept_unmasked_frames.rs
@@ -26,14 +26,14 @@ fn main() {
                 Ok(response)
             };
 
-            let config = Some(WebSocketConfig {
-                // This setting allows to accept client frames which are not masked
-                // This is not in compliance with RFC 6455 but might be handy in some
-                // rare cases where it is necessary to integrate with existing/legacy
-                // clients which are sending unmasked frames
-                accept_unmasked_frames: true,
-                ..<_>::default()
-            });
+            let config = Some(
+                WebSocketConfig::default()
+                    // This setting allows to accept client frames which are not masked
+                    // This is not in compliance with RFC 6455 but might be handy in some
+                    // rare cases where it is necessary to integrate with existing/legacy
+                    // clients which are sending unmasked frames
+                    .accept_unmasked_frames(true),
+            );
 
             let mut websocket = accept_hdr_with_config(stream.unwrap(), callback, config).unwrap();
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -30,6 +30,14 @@ pub enum Role {
 }
 
 /// The configuration for WebSocket connection.
+///
+/// # Example
+/// ```
+/// # use tungstenite::protocol::WebSocketConfig;;
+/// let conf = WebSocketConfig::default()
+///     .read_buffer_size(256 * 1024)
+///     .write_buffer_size(256 * 1024);
+/// ```
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct WebSocketConfig {

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -37,7 +37,7 @@ fn write_flush_behaviour() {
     let mut ws = WebSocket::from_raw_socket(
         MockWrite::default(),
         tungstenite::protocol::Role::Server,
-        Some(WebSocketConfig { write_buffer_size: WRITE_BUFFER_SIZE, ..<_>::default() }),
+        Some(WebSocketConfig::default().write_buffer_size(WRITE_BUFFER_SIZE)),
     );
 
     assert_eq!(ws.get_ref().written_bytes, 0);


### PR DESCRIPTION
- Add `WebSocketConfig::read_buffer_size` default 128 KiB.
- Make `WebSocketConfig` non-exhaustive & add builder style construction fns.
- Remove deprecated `WebSocketConfig::max_send_queue`.

Note this also doubles the read buffer len in https://github.com/snapview/tungstenite-rs/pull/465 from 64 -> 128k providing a boost in bench perf, since the bench has 100k messages ready to go.

The bench is a bit artificial to deduce the best default, but 128k is the current default for the write buffer so seems a good place to start.

```
read+unmask 100k small messages (server)
                        time:   [7.5623 ms 7.5700 ms 7.6009 ms]
                        change: [-3.5836% -3.0376% -2.4881%] (p = 0.07 > 0.05)

read 100k small messages (client)
                        time:   [7.1301 ms 7.1658 ms 7.1747 ms]
                        change: [-4.4713% -2.4551% -0.3652%] (p = 0.13 > 0.05)
```