### PR TITLE
message: fix documentation on Message::binary()

### DIFF
--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -183,7 +183,7 @@ impl Message {
         Message::Text(string.into())
     }
 
-    /// Create a new binary WebSocket message by converting to `Vec<u8>`.
+    /// Create a new binary WebSocket message by converting to `Bytes`.
     pub fn binary<B>(bin: B) -> Message
     where
         B: Into<Bytes>,


### PR DESCRIPTION
https://github.com/snapview/tungstenite-rs/blob/fb9c15417813f0c2f3209e22eece309544895d79/src/protocol/message.rs#L186

here it should say `Bytes`, not `Vec<u8>`, didn't catch this yesterday.