### PR TITLE
feat: add unsafe Utf8Bytes::from_bytes_unchecked

### DIFF
--- a/src/protocol/frame/utf8.rs
+++ b/src/protocol/frame/utf8.rs
@@ -22,7 +22,9 @@ impl Utf8Bytes {
 
     /// Creates from a [`Bytes`] object without checking the encoding.
     ///
-    /// SAFETY: The bytes passed in must be valid UTF-8.
+    /// # Safety
+    ///
+    /// The bytes passed in must be valid UTF-8.
     pub unsafe fn from_bytes_unchecked(bytes: Bytes) -> Self {
         Self(bytes)
     }

--- a/src/protocol/frame/utf8.rs
+++ b/src/protocol/frame/utf8.rs
@@ -19,6 +19,13 @@ impl Utf8Bytes {
         // SAFETY: is valid uft8
         unsafe { str::from_utf8_unchecked(&self.0) }
     }
+
+    /// Creates from a [`Bytes`] object without checking the encoding.
+    ///
+    /// SAFETY: The bytes passed in must be valid UTF-8.
+    pub unsafe fn from_bytes_unchecked(bytes: Bytes) -> Self {
+        Self(bytes)
+    }
 }
 
 impl std::ops::Deref for Utf8Bytes {


### PR DESCRIPTION
I'm in a case where I already have a `Utf8Bytes` equivalent in my own codebase (a simple `Bytes` wrapper), therefore I am sure that this [`Bytes`] is valid utf8 data and I want to convert it to a `Utf8Bytes`.

However there is currently now way to construct a `Utf8Bytes` without checking the encoding even if we are sure about it.

I propose to add the `from_bytes_unchecked` which is similar to `String::from_utf8_unchecked`.