### PR TITLE
Remove byteorder, use bytes::Buf::get_uint instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ __rustls-tls = ["rustls", "rustls-pki-types"]
 
 [dependencies]
 data-encoding = { version = "2", optional = true }
-byteorder = "1.3.2"
 bytes = "1.9.0"
 http = { version = "1.0", optional = true }
 httparse = { version = "1.3.4", optional = true }

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -161,13 +161,9 @@ impl FrameHeader {
             let length_length = LengthFormat::for_byte(length_byte).extra_bytes();
             if length_length > 0 {
                 const SIZE: usize = mem::size_of::<u64>();
+                assert!(length_length <= SIZE, "length exceeded size of u64");
+                let start = SIZE - length_length;
                 let mut buffer = [0; SIZE];
-                let start = match SIZE.checked_sub(length_length) {
-                    Some(start) => start,
-                    None => {
-                        panic!("the integer can fit {} bytes, but {} is given", SIZE, length_length)
-                    }
-                };
                 match cursor.read_exact(&mut buffer[start..]) {
                     Err(ref err) if err.kind() == ErrorKind::UnexpectedEof => return Ok(None),
                     Err(err) => return Err(err.into()),


### PR DESCRIPTION
`byteorder` was only used in one place and since bytes crate implements similar functionality it lets us drop it pretty easily.