### PR TITLE
Add `WebSocketConfig::read_buffer_size` docs explaining performance/memory tradeoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 0.26.1
+# Unreleased
+- Add `WebSocketConfig::read_buffer_size` docs explaining performance/memory tradeoff.
 
+# 0.26.1
 - Fix/revert unsoundness that could lead to UB with dodgy `Read` stream implementations.
 
 # 0.26.0
@@ -11,7 +13,8 @@
 
 - New `Payload` type for `Message` that allows sending messages with a payload that can be cheaply cloned (`Bytes`).
   Long standing [issue](https://github.com/snapview/tungstenite-rs/issues/96) solved!
-- Add `WebSocketConfig::read_buffer_size` default 128 KiB.
+- Add `WebSocketConfig::read_buffer_size` default 128 KiB. This improves high load read performance.
+  **Note: This default increases memory usage compared to previous versions particularly for users expecting a high number of connections. Configure 4-8 KiB to get a similar memory usage to 0.24**.
 - Make `WebSocketConfig` non-exhaustive & add builder style construction fns.
 - Remove deprecated `WebSocketConfig::max_send_queue`.
 - Trim spaces on `Sec-WebSocket-Protocol` header.

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -44,7 +44,16 @@ pub enum Role {
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct WebSocketConfig {
-    /// Read buffer capacity. The default value is 128 KiB.
+    /// Read buffer capacity. This buffer is eagerly allocated and used for receiving
+    /// messages.
+    ///
+    /// For high read load scenarios a larger buffer, e.g. 128 KiB, improves performance.
+    ///
+    /// For scenarios where you expect a lot of connections and don't need high read load
+    /// performance a smaller buffer, e.g. 4 KiB, would be appropriate to lower total
+    /// memory usage.
+    ///
+    /// The default value is 128 KiB.
     pub read_buffer_size: usize,
     /// The target minimum size of the write buffer to reach before writing the data
     /// to the underlying stream.


### PR DESCRIPTION
- Add `WebSocketConfig::read_buffer_size` docs explaining performance/memory tradeoff.
- Update 0.25.0 changelog explaining change to memory use.

Relates to #480 