### PR TITLE
Implement `From<Bytes>` for `Message`

### DIFF
--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -294,6 +294,12 @@ impl<'b> From<&'b [u8]> for Message {
     }
 }
 
+impl From<Bytes> for Message {
+    fn from(data: Bytes) -> Self {
+        Message::binary(data)
+    }
+}
+
 impl From<Vec<u8>> for Message {
     #[inline]
     fn from(data: Vec<u8>) -> Self {
@@ -335,6 +341,14 @@ mod tests {
     fn binary_convert() {
         let bin = [6u8, 7, 8, 9, 10, 241];
         let msg = Message::from(&bin[..]);
+        assert!(msg.is_binary());
+        assert!(msg.into_text().is_err());
+    }
+
+    #[test]
+    fn binary_convert_bytes() {
+        let bin = Bytes::from_iter([6u8, 7, 8, 9, 10, 241]);
+        let msg = Message::from(bin);
         assert!(msg.is_binary());
         assert!(msg.into_text().is_err());
     }


### PR DESCRIPTION
Implementation `From<Bytes>` for `Message` is missing.

The internal representation of the binary message is `Bytes`. It would be convenient to have related `From` implementation, especially for application code that is designed to work with `Bytes` as opposed to `Vec<u8>`.