### PR TITLE
Update WebSocketConfig::max_write_buffer_size default value

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -97,7 +97,7 @@ impl Default for WebSocketConfig {
         Self {
             read_buffer_size: 128 * 1024,
             write_buffer_size: 128 * 1024,
-            max_write_buffer_size: 16 * 1024 * 1024,
+            max_write_buffer_size: 64 * 1024 * 1024,
             max_message_size: Some(64 << 20),
             max_frame_size: Some(16 << 20),
             accept_unmasked_frames: false,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -97,7 +97,7 @@ impl Default for WebSocketConfig {
         Self {
             read_buffer_size: 128 * 1024,
             write_buffer_size: 128 * 1024,
-            max_write_buffer_size: usize::MAX,
+            max_write_buffer_size: 16 * 1024 * 1024,
             max_message_size: Some(64 << 20),
             max_frame_size: Some(16 << 20),
             accept_unmasked_frames: false,


### PR DESCRIPTION
Change default value of websocketconfig::max_write_buffer_size to be sane and consistent with the documentation