### PR TITLE
Make default value sane for WebSocketConfig::max_write_buffer_size

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -97,7 +97,7 @@ impl Default for WebSocketConfig {
         Self {
             read_buffer_size: 128 * 1024,
             write_buffer_size: 128 * 1024,
-            max_write_buffer_size: usize::MAX,
+            max_write_buffer_size: 16 * 1024 * 1024,
             max_message_size: Some(64 << 20),
             max_frame_size: Some(16 << 20),
             accept_unmasked_frames: false,


### PR DESCRIPTION
Default value of WebSocketConfig::max_write_buffer_size is mentioned in documentation is 64MiB, but in code it is usize::MAX, which is both inconsistent and unreasonable.