### PR TITLE
Add end to end "send+recv" benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ optional = true
 version = "0.26"
 
 [dev-dependencies]
-criterion = "0.5.0"
+criterion = "0.6"
 env_logger = "0.11"
 input_buffer = "0.5.0"
 rand = "0.9.0"
@@ -82,6 +82,10 @@ harness = false
 
 [[bench]]
 name = "read"
+harness = false
+
+[[bench]]
+name = "e2e"
 harness = false
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ harness = false
 [[bench]]
 name = "e2e"
 harness = false
+required-features = ["handshake"]
 
 [[example]]
 name = "client"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Testing
 Tungstenite is thoroughly tested and passes the [Autobahn Test Suite](https://github.com/crossbario/autobahn-testsuite) for
 WebSockets. It is also covered by internal unit tests as well as possible.
 
+Benchmark
+---------
+Benches are in [./benches](./benches/).
+* Run all with `cargo bench --bench \* -- --quick --noplot`
+* Run a particular set with, say "e2e", with `cargo bench --bench e2e -- --quick --noplot`
+
 Contributing
 ------------
 

--- a/benches/buffer.rs
+++ b/benches/buffer.rs
@@ -1,9 +1,12 @@
-use std::io::{Cursor, Read, Result as IoResult};
+#![allow(clippy::incompatible_msrv)] // msrv doesn't apply to benches
 
 use bytes::Buf;
-use criterion::*;
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use input_buffer::InputBuffer;
-
+use std::{
+    hint::black_box,
+    io::{Cursor, Read, Result as IoResult},
+};
 use tungstenite::buffer::ReadBuffer;
 
 const CHUNK_SIZE: usize = 4096;

--- a/benches/e2e.rs
+++ b/benches/e2e.rs
@@ -39,7 +39,7 @@ fn benchmark(c: &mut Criterion) {
         });
 
         let (mut client, _) = tungstenite::client::connect_with_config(
-            format!("ws://localhost:{port}"),
+            format!("ws://127.0.0.1:{port}"),
             Some(conf),
             3,
         )

--- a/benches/e2e.rs
+++ b/benches/e2e.rs
@@ -1,0 +1,92 @@
+//! Benchmarks for read performance.
+use bytes::Bytes;
+use criterion::{BatchSize, Criterion};
+use rand::{
+    distr::{Alphanumeric, SampleString},
+    rngs::SmallRng,
+    SeedableRng,
+};
+use std::net::TcpListener;
+use tungstenite::{accept_hdr_with_config, protocol::WebSocketConfig, Message};
+
+/// Binary message meaning "stop".
+const B_STOP: Bytes = Bytes::from_static(b"stop");
+
+fn benchmark(c: &mut Criterion) {
+    /// Benchmark that starts a simple server and client then sends (writes+flush) a
+    /// single text message client->server and reads a single response text message
+    /// server->client. Both message will be of the given `msg_len` size.
+    fn send_and_recv(msg_len: usize, b: &mut criterion::Bencher<'_>) {
+        let socket = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = socket.local_addr().unwrap().port();
+        let conf = WebSocketConfig::default()
+            .max_message_size(Some(usize::MAX))
+            .max_frame_size(Some(usize::MAX));
+
+        let server_thread = std::thread::spawn(move || {
+            // single thread / single client server
+            let (stream, _) = socket.accept().unwrap();
+            let mut websocket =
+                accept_hdr_with_config(stream, |_: &_, res| Ok(res), Some(conf)).unwrap();
+            loop {
+                let uppercase_txt = match websocket.read().unwrap() {
+                    Message::Text(msg) => msg.to_ascii_uppercase(),
+                    Message::Binary(msg) if msg == B_STOP => return,
+                    msg => panic!("Unexpected msg: {msg:?}"),
+                };
+                websocket.send(Message::text(uppercase_txt)).unwrap();
+            }
+        });
+
+        let (mut client, _) = tungstenite::client::connect_with_config(
+            format!("ws://localhost:{port}"),
+            Some(conf),
+            3,
+        )
+        .unwrap();
+        let mut rng = SmallRng::seed_from_u64(123);
+
+        b.iter_batched(
+            || {
+                let msg = Alphanumeric.sample_string(&mut rng, msg_len);
+                let expected_response = msg.to_ascii_uppercase();
+                (msg, expected_response)
+            },
+            |(txt, expected_response)| {
+                client.send(Message::text(txt)).unwrap();
+                let response = client.read().unwrap();
+                match response {
+                    Message::Text(v) => assert_eq!(v, expected_response),
+                    msg => panic!("Unexpected response msg: {msg:?}"),
+                };
+            },
+            BatchSize::PerIteration,
+        );
+
+        // cleanup
+        client.send(Message::binary(B_STOP)).unwrap();
+        server_thread.join().unwrap();
+    }
+
+    // bench sending & receiving various message sizes 1Kib to 1Gib.
+    for len in (0..21).map(|n| 1024 * 2_usize.pow(n)) {
+        let human_len = HumanLen(len);
+        c.bench_function(&format!("send+recv {human_len}"), |b| send_and_recv(len, b));
+    }
+}
+
+struct HumanLen(usize);
+
+impl std::fmt::Display for HumanLen {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            n if n < 1024 => write!(f, "{n} B"),
+            n if n < 1024 * 1024 => write!(f, "{} KiB", n / 1024),
+            n if n < 1024 * 1024 * 1024 => write!(f, "{} MiB", n / (1024 * 1024)),
+            n => write!(f, "{} GiB", n / (1024 * 1024 * 1024)),
+        }
+    }
+}
+
+criterion::criterion_group!(read_benches, benchmark);
+criterion::criterion_main!(read_benches);

--- a/benches/e2e.rs
+++ b/benches/e2e.rs
@@ -19,9 +19,7 @@ fn benchmark(c: &mut Criterion) {
     fn send_and_recv(msg_len: usize, b: &mut criterion::Bencher<'_>) {
         let socket = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = socket.local_addr().unwrap().port();
-        let conf = WebSocketConfig::default()
-            .max_message_size(Some(usize::MAX))
-            .max_frame_size(Some(usize::MAX));
+        let conf = WebSocketConfig::default().max_message_size(None).max_frame_size(None);
 
         let server_thread = std::thread::spawn(move || {
             // single thread / single client server

--- a/benches/e2e.rs
+++ b/benches/e2e.rs
@@ -1,4 +1,4 @@
-//! Benchmarks for read performance.
+//! Benchmarks for end to end performance including real `Read` & `Write` impls.
 use bytes::Bytes;
 use criterion::{BatchSize, Criterion, Throughput};
 use rand::{
@@ -68,8 +68,8 @@ fn benchmark(c: &mut Criterion) {
         server_thread.join().unwrap();
     }
 
-    // bench sending & receiving various sizes 1Kib to 1Gib.
-    for len in (0..21).map(|n| 1024 * 2_usize.pow(n)) {
+    // bench sending & receiving various sizes 512B to 1GiB.
+    for len in (0..8).map(|n| 512 * 8_usize.pow(n)) {
         let mut group = c.benchmark_group("send+recv");
         group
             .throughput(Throughput::Bytes(len as u64 * 2)) // *2 as we send and then recv it


### PR DESCRIPTION
Introduce e2e.rs containing end to end style benchmarks using a real `std::net::TcpListener`.

Run with `cargo bench --bench e2e -- --quick --noplot`.

The benchmarks sets up a very simple ws server & client and sends a single message client->server, the server sends a single response server->client (not an echo!).

This means the bench should provide good regression coverage of end to end text message performance.

This benchmark is configured to run at varying sizes 512 B up to 1 GiB. As such it highlights #493, current output

```
send+recv/512 B         time:   [13.049 µs 13.187 µs 13.222 µs]
                        thrpt:  [73.860 MiB/s 74.053 MiB/s 74.838 MiB/s]

send+recv/4 KiB         time:   [15.441 µs 15.544 µs 15.955 µs]
                        thrpt:  [489.67 MiB/s 502.60 MiB/s 505.95 MiB/s]

send+recv/32 KiB        time:   [29.262 µs 29.900 µs 30.059 µs]
                        thrpt:  [2.0305 GiB/s 2.0413 GiB/s 2.0858 GiB/s]

send+recv/256 KiB       time:   [120.17 µs 123.55 µs 124.39 µs]
                        thrpt:  [3.9253 GiB/s 3.9521 GiB/s 4.0631 GiB/s]

send+recv/2 MiB         time:   [1.0266 ms 1.0371 ms 1.0398 ms]
                        thrpt:  [3.7569 GiB/s 3.7664 GiB/s 3.8049 GiB/s]

send+recv/16 MiB        time:   [28.325 ms 28.398 ms 28.688 ms]
                        thrpt:  [1.0893 GiB/s 1.1004 GiB/s 1.1033 GiB/s]

send+recv/128 MiB       time:   [965.45 ms 968.60 ms 981.18 ms]
                        thrpt:  [260.91 MiB/s 264.30 MiB/s 265.16 MiB/s]

send+recv/1 GiB         time:   [35.263 s 35.263 s 35.263 s]
                        thrpt:  [58.078 MiB/s 58.078 MiB/s 58.078 MiB/s]
```