### PR TITLE
Fix clippy warnings: Inline `format!` args

### DIFF
--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -18,7 +18,7 @@ fn update_reports() -> Result<()> {
 }
 
 fn run_test(case: u32) -> Result<()> {
-    info!("Running test case {}", case);
+    info!("Running test case {case}");
     let case_url = format!("ws://localhost:9001/runCase?case={case}&agent={AGENT}");
     let (mut socket, _) = connect(case_url)?;
     loop {

--- a/src/protocol/frame/frame.rs
+++ b/src/protocol/frame/frame.rs
@@ -141,12 +141,12 @@ impl FrameHeader {
             if cursor.read(&mut head)? != 2 {
                 return Ok(None);
             }
-            trace!("Parsed headers {:?}", head);
+            trace!("Parsed headers {head:?}");
             (head[0], head[1])
         };
 
-        trace!("First: {:b}", first);
-        trace!("Second: {:b}", second);
+        trace!("First: {first:b}");
+        trace!("Second: {second:b}");
 
         let is_final = first & 0x80 != 0;
 
@@ -155,10 +155,10 @@ impl FrameHeader {
         let rsv3 = first & 0x10 != 0;
 
         let opcode = OpCode::from(first & 0x0F);
-        trace!("Opcode: {:?}", opcode);
+        trace!("Opcode: {opcode:?}");
 
         let masked = second & 0x80 != 0;
-        trace!("Masked: {:?}", masked);
+        trace!("Masked: {masked:?}");
 
         let length = {
             let length_byte = second & 0x7F;

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -68,7 +68,7 @@ mod string_collect {
 
         pub fn into_string(self) -> Result<String> {
             if let Some(incomplete) = self.incomplete {
-                Err(Error::Utf8(format!("incomplete string: {:?}", incomplete)))
+                Err(Error::Utf8(format!("incomplete string: {incomplete:?}")))
             } else {
                 Ok(self.data)
             }

--- a/tests/auto_pong_flush.rs
+++ b/tests/auto_pong_flush.rs
@@ -71,7 +71,7 @@ fn read_usage_auto_pong_flush() {
 
     // Receiving a ping should auto scheduled a pong on next read or write (but not written yet).
     let msg = ws.read().unwrap();
-    assert!(matches!(msg, Message::Ping(_)), "Unexpected msg {:?}", msg);
+    assert!(matches!(msg, Message::Ping(_)), "Unexpected msg {msg:?}");
     assert_eq!(ws.get_ref().read_calls, 1);
     assert!(ws.get_ref().written_data.is_empty(), "Unexpected {:?}", ws.get_ref());
     assert!(ws.get_ref().flushed_data.is_empty(), "Unexpected {:?}", ws.get_ref());
@@ -81,8 +81,7 @@ fn read_usage_auto_pong_flush() {
     let next = ws.read().unwrap_err();
     assert!(
         matches!(next, tungstenite::Error::Io(ref err) if err.kind() == io::ErrorKind::WouldBlock),
-        "Unexpected read err {:?}",
-        next
+        "Unexpected read err {next:?}",
     );
     assert_eq!(ws.get_ref().read_calls, 2);
     assert!(!ws.get_ref().written_data.is_empty(), "Should have written a pong frame");
@@ -101,8 +100,7 @@ fn read_usage_auto_pong_flush() {
     let next = ws.read().unwrap_err();
     assert!(
         matches!(next, tungstenite::Error::Io(ref err) if err.kind() == io::ErrorKind::WouldBlock),
-        "Unexpected read err {:?}",
-        next
+        "Unexpected read err {next:?}",
     );
     assert_eq!(ws.get_ref().read_calls, 3);
     assert_eq!(ws.get_ref().write_calls, 1);
@@ -114,8 +112,7 @@ fn read_usage_auto_pong_flush() {
     let next = ws.read().unwrap_err();
     assert!(
         matches!(next, tungstenite::Error::Io(ref err) if err.kind() == io::ErrorKind::WouldBlock),
-        "Unexpected read err {:?}",
-        next
+        "Unexpected read err {next:?}",
     );
     assert_eq!(ws.get_ref().read_calls, 4);
     assert_eq!(ws.get_ref().write_calls, 1);

--- a/tests/client_headers.rs
+++ b/tests/client_headers.rs
@@ -43,7 +43,7 @@ fn test_headers() {
         let err = client.read().unwrap_err(); // now we should get ConnectionClosed
         match err {
             Error::ConnectionClosed => {}
-            _ => panic!("unexpected error: {:?}", err),
+            _ => panic!("unexpected error: {err:?}"),
         }
     });
 
@@ -87,7 +87,7 @@ fn test_headers() {
     let err = client_handler.read().unwrap_err(); // now we should get ConnectionClosed
     match err {
         Error::ConnectionClosed => {}
-        _ => panic!("unexpected error: {:?}", err),
+        _ => panic!("unexpected error: {err:?}"),
     }
 
     drop(client_handler);

--- a/tests/connection_reset.rs
+++ b/tests/connection_reset.rs
@@ -33,7 +33,7 @@ where
 
     let client_thread = spawn(move || {
         let (client, _) =
-            connect(format!("ws://localhost:{}/socket", port)).expect("Can't connect to port");
+            connect(format!("ws://localhost:{port}/socket")).expect("Can't connect to port");
 
         client_task(client);
     });
@@ -59,7 +59,7 @@ fn test_server_close() {
             let err = cli_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
-                _ => panic!("unexpected error: {:?}", err),
+                _ => panic!("unexpected error: {err:?}"),
             }
         },
         |mut srv_sock| {
@@ -74,7 +74,7 @@ fn test_server_close() {
             let err = srv_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
-                _ => panic!("unexpected error: {:?}", err),
+                _ => panic!("unexpected error: {err:?}"),
             }
         },
     );
@@ -95,7 +95,7 @@ fn test_evil_server_close() {
             let err = cli_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
-                _ => panic!("unexpected error: {:?}", err),
+                _ => panic!("unexpected error: {err:?}"),
             }
         },
         |mut srv_sock| {
@@ -131,7 +131,7 @@ fn test_client_close() {
             let err = cli_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
-                _ => panic!("unexpected error: {:?}", err),
+                _ => panic!("unexpected error: {err:?}"),
             }
         },
         |mut srv_sock| {
@@ -146,7 +146,7 @@ fn test_client_close() {
             let err = srv_sock.read().unwrap_err(); // now we should get ConnectionClosed
             match err {
                 Error::ConnectionClosed => {}
-                _ => panic!("unexpected error: {:?}", err),
+                _ => panic!("unexpected error: {err:?}"),
             }
         },
     );

--- a/tests/no_send_after_close.rs
+++ b/tests/no_send_after_close.rs
@@ -34,7 +34,7 @@ fn test_no_send_after_close() {
         let err = client.read().unwrap_err(); // now we should get ConnectionClosed
         match err {
             Error::ConnectionClosed => {}
-            _ => panic!("unexpected error: {:?}", err),
+            _ => panic!("unexpected error: {err:?}"),
         }
     });
 
@@ -49,7 +49,7 @@ fn test_no_send_after_close() {
 
     match err.unwrap_err() {
         Error::Protocol(s) => assert_eq!(s, ProtocolError::SendAfterClosing),
-        e => panic!("unexpected error: {:?}", e),
+        e => panic!("unexpected error: {e:?}"),
     }
 
     drop(client_handler);

--- a/tests/receive_after_init_close.rs
+++ b/tests/receive_after_init_close.rs
@@ -35,7 +35,7 @@ fn test_receive_after_init_close() {
         let err = client.read().unwrap_err(); // now we should get ConnectionClosed
         match err {
             Error::ConnectionClosed => {}
-            _ => panic!("unexpected error: {:?}", err),
+            _ => panic!("unexpected error: {err:?}"),
         }
     });
 
@@ -53,7 +53,7 @@ fn test_receive_after_init_close() {
     let err = client_handler.read().unwrap_err(); // now we should get ConnectionClosed
     match err {
         Error::ConnectionClosed => {}
-        _ => panic!("unexpected error: {:?}", err),
+        _ => panic!("unexpected error: {err:?}"),
     }
 
     drop(client_handler);


### PR DESCRIPTION
This fixes all current clippy warnings.