### PR TITLE
Proper strigification of http::Version

### DIFF
--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -19,6 +19,7 @@ use super::{
 };
 use crate::{
     error::{Error, ProtocolError, Result, SubProtocolError, UrlError},
+    handshake::version_as_str,
     protocol::{Role, WebSocket, WebSocketConfig},
 };
 
@@ -112,9 +113,9 @@ pub fn generate_request(mut request: Request) -> Result<(Vec<u8>, String)> {
     let mut req = Vec::new();
     write!(
         req,
-        "GET {path} {version:?}\r\n",
+        "GET {path} {version}\r\n",
         path = request.uri().path_and_query().ok_or(Error::Url(UrlError::NoPathOrQuery))?.as_str(),
-        version = request.version()
+        version = version_as_str(request.version())?,
     )
     .unwrap();
 

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -20,6 +20,7 @@ use super::{
 };
 use crate::{
     error::{Error, ProtocolError, Result},
+    handshake::version_as_str,
     protocol::{Role, WebSocket, WebSocketConfig},
 };
 
@@ -97,8 +98,8 @@ pub fn create_response_with_body<T1, T2>(
 pub fn write_response<T>(mut w: impl io::Write, response: &HttpResponse<T>) -> Result<()> {
     writeln!(
         w,
-        "{version:?} {status}\r",
-        version = response.version(),
+        "{version} {status}\r",
+        version = version_as_str(response.version())?,
         status = response.status()
     )?;
 


### PR DESCRIPTION
It's bad idea to use `fmt::Debug` here because debug is inherently non-stable and also because it breaks with `-Zfmt-debug=none`.

I'm not adding patch for `http` create because `http` strigification doesn't make any sense for http2 and http3 (i.e. it is never used on the wire).

This fixes #510 