### PR TITLE
Implement into_inner to get the underlying stream

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -199,6 +199,11 @@ impl<Stream> WebSocket<Stream> {
         }
     }
 
+    /// Consumes the `WebSocket` and returns the underlying stream.
+    pub fn into_inner(self) -> Stream {
+        self.socket
+    }
+
     /// Returns a shared reference to the inner stream.
     pub fn get_ref(&self) -> &Stream {
         &self.socket


### PR DESCRIPTION
Can be handy for certain usecases

fastwebsockets implements this as well https://docs.rs/fastwebsockets/latest/fastwebsockets/struct.WebSocket.html#method.into_inner

tokio-tungstenite users will need into_inner support on the `WebSocketStream`/`AllowStd`. I plan to open a PR for that if this is merged and a new release cut.