### PR TITLE
Update sha1 to version 0.11.0 and rand to version 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ bytes = "1.9.0"
 http = { version = "1.0", optional = true }
 httparse = { version = "1.3.4", optional = true }
 log = "0.4.8"
-rand = "0.9.0"
-sha1 = { version = "0.10", optional = true }
+rand = "0.10.0"
+sha1 = { version = "0.11.0", optional = true }
 thiserror = "2.0.7"
 url = { version = "2.1.0", optional = true }
 
@@ -65,7 +65,7 @@ version = "0.26"
 criterion = "0.6"
 env_logger = "0.11"
 input_buffer = "0.5.0"
-rand = "0.9.0"
+rand = "0.10.0"
 socket2 = "0.6.0"
 
 [profile.bench]


### PR DESCRIPTION
The main release version of `sha1` has an issue where the deeply-nested dependency `generic-array` still includes `doc_auto_cfg`, which is deprecated in rust nightly. Recent docs.rs builds fail when the old version is included. This bumps the version to stop the issue.

`rand` has a similar issue.

I've managed to request updates from all other upstream nested dependencies; those aren't pre-release versions, so Cargo should be able to update them OK.