### PR TITLE
security: upgrade rand from 0.8 to 0.9 to fix RUSTSEC-2026-0097

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bytes = "1.0"
 http = { version = "1.0", optional = true }
 httparse = { version = "1.3.4", optional = true }
 log = "0.4.8"
-rand = "0.8.0"
+rand = "0.9.0"
 sha1 = { version = "0.10", optional = true }
 thiserror = "1.0.23"
 url = { version = "2.1.0", optional = true }
@@ -64,7 +64,7 @@ version = "0.26"
 criterion = "0.5.0"
 env_logger = "0.10.0"
 input_buffer = "0.5.0"
-rand = "0.8.4"
+rand = "0.9.0"
 socket2 = "0.5.5"
 
 [[bench]]


### PR DESCRIPTION
## Summary
Upgrades and from 0.8 to 0.9 to fix the unsoundness vulnerability [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097).

## Changes
- and 0.8.0  0.9.0 (main dependency)
- and 0.8.4  0.9.0 (dev dependency)

## Compatibility
The and::random() API used in the codebase is compatible with both 0.8 and 0.9.

## Security Impact
This resolves the unsoundness issue when using and::rng() with a custom logger.

## Note
This fix is for the 0.21.x release line. The same fix should be applied to other maintained branches.