### PR TITLE
Validate Sec-WebSocket-Key length per RFC 6455 §4.2.1.5

### DIFF
--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use http::{
+    header::HeaderName,
     response::Builder, HeaderMap, Request as HttpRequest, Response as HttpResponse, StatusCode,
 };
 use httparse::Status;
@@ -70,6 +71,12 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
         .headers()
         .get("Sec-WebSocket-Key")
         .ok_or(Error::Protocol(ProtocolError::MissingSecWebSocketKey))?;
+
+        if key.len() != 24 {
+        return Err(Error::Protocol(ProtocolError::InvalidHeader(
+            Box::new(HeaderName::from_static("sec-websocket-key")),
+        )));
+    }
 
     let builder = Response::builder()
         .status(StatusCode::SWITCHING_PROTOCOLS)
@@ -321,5 +328,47 @@ mod tests {
             response.headers().get("Sec-WebSocket-Accept").unwrap(),
             b"s3pPLMBiTxaQ9kYGzzhZRbK+xOo=".as_ref()
         );
+    }
+
+    #[test]
+    fn test_invalid_websocket_key_empty() {
+        const DATA: &[u8] = b"\
+            GET /script.ws HTTP/1.1\r\n\
+            Host: foo.com\r\n\
+            Connection: upgrade\r\n\
+            Upgrade: websocket\r\n\
+            Sec-WebSocket-Version: 13\r\n\
+            Sec-WebSocket-Key: \r\n\
+            \r\n";
+        let (_, req) = Request::try_parse(DATA).unwrap().unwrap();
+        assert!(create_response(&req).is_err());
+    }
+
+    #[test]
+    fn test_invalid_websocket_key_too_long() {
+        const DATA: &[u8] = b"\
+            GET /script.ws HTTP/1.1\r\n\
+            Host: foo.com\r\n\
+            Connection: upgrade\r\n\
+            Upgrade: websocket\r\n\
+            Sec-WebSocket-Version: 13\r\n\
+            Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==AAAAAAAAAA\r\n\
+            \r\n";
+        let (_, req) = Request::try_parse(DATA).unwrap().unwrap();
+        assert!(create_response(&req).is_err());
+    }
+
+    #[test]
+    fn test_valid_websocket_key_length() {
+        const DATA: &[u8] = b"\
+            GET /script.ws HTTP/1.1\r\n\
+            Host: foo.com\r\n\
+            Connection: upgrade\r\n\
+            Upgrade: websocket\r\n\
+            Sec-WebSocket-Version: 13\r\n\
+            Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+            \r\n";
+        let (_, req) = Request::try_parse(DATA).unwrap().unwrap();
+        assert!(create_response(&req).is_ok());
     }
 }

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use http::{
-    header::HeaderName,
-    response::Builder, HeaderMap, Request as HttpRequest, Response as HttpResponse, StatusCode,
+    header::HeaderName, response::Builder, HeaderMap, Request as HttpRequest,
+    Response as HttpResponse, StatusCode,
 };
 use httparse::Status;
 use log::*;

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -72,10 +72,10 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
         .get("Sec-WebSocket-Key")
         .ok_or(Error::Protocol(ProtocolError::MissingSecWebSocketKey))?;
 
-        if key.len() != 24 {
-        return Err(Error::Protocol(ProtocolError::InvalidHeader(
-            Box::new(HeaderName::from_static("sec-websocket-key")),
-        )));
+    if key.len() != 24 {
+        return Err(Error::Protocol(ProtocolError::InvalidHeader(Box::new(
+            HeaderName::from_static("sec-websocket-key"),
+        ))));
     }
 
     let builder = Response::builder()


### PR DESCRIPTION
Problem: tungstenite does not validate the length of the Sec-WebSocket-Key header. RFC 6455 §4.2.1.5 requires this value to be a base64-encoded 16-byte nonce, which is always exactly 24 characters long. Currently, clients sending empty or arbitrarily long keys are accepted, causing unnecessary SHA-1 and base64 computation.
Related to #377.
Fix: Added a length check in create_response that returns InvalidHeader if the key length is not exactly 24 characters.
Tests added:

Empty key → rejected
Oversized key → rejected
Valid 24-char key → accepted

Note: test_no_send_after_close fails on Windows without these changes — pre-existing issue unrelated to this PR.