### PR TITLE
match Upgrade header token-wise like the Connection header

### DIFF
--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -233,7 +233,7 @@ impl VerifyData {
         if !headers
             .get("Upgrade")
             .and_then(|h| h.to_str().ok())
-            .map(|h| h.eq_ignore_ascii_case("websocket"))
+            .map(|h| h.split([' ', ',']).any(|p| p.eq_ignore_ascii_case("websocket")))
             .unwrap_or(false)
         {
             return Err(Error::Protocol(ProtocolError::MissingUpgradeWebSocketHeader));
@@ -453,5 +453,22 @@ mod tests {
             req_bytes.windows(expected_header.len()).any(|window| window == expected_header),
             "Request should preserve the raw Latin-1 bytes"
         );
+    }
+
+    #[test]
+    fn verify_response_upgrade_token_list() {
+        let key = "dGhlIHNhbXBsZSBub25jZQ==";
+        let accept_key = crate::handshake::derive_accept_key(key.as_bytes());
+        let verify = super::VerifyData { accept_key: accept_key.clone(), subprotocols: None };
+
+        let response = http::Response::builder()
+            .status(http::StatusCode::SWITCHING_PROTOCOLS)
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket, h2c")
+            .header("Sec-WebSocket-Accept", accept_key)
+            .body(Option::<Vec<u8>>::None)
+            .unwrap();
+
+        assert!(verify.verify_response(response).is_ok());
     }
 }

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -57,7 +57,7 @@ fn create_parts<T>(request: &HttpRequest<T>) -> Result<Builder> {
         .headers()
         .get("Upgrade")
         .and_then(|h| h.to_str().ok())
-        .map(|h| h.eq_ignore_ascii_case("websocket"))
+        .map(|h| h.split([' ', ',']).any(|p| p.eq_ignore_ascii_case("websocket")))
         .unwrap_or(false)
     {
         return Err(Error::Protocol(ProtocolError::MissingUpgradeWebSocketHeader));
@@ -386,6 +386,20 @@ mod tests {
     #[test]
     fn test_valid_websocket_key() {
         let req = request_with_key("dGhlIHNhbXBsZSBub25jZQ==");
+        assert!(create_response(&req).is_ok());
+    }
+
+    #[test]
+    fn request_upgrade_token_list() {
+        const DATA: &[u8] = b"\
+            GET /script.ws HTTP/1.1\r\n\
+            Host: foo.com\r\n\
+            Connection: upgrade\r\n\
+            Upgrade: websocket, h2c\r\n\
+            Sec-WebSocket-Version: 13\r\n\
+            Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+            \r\n";
+        let (_, req) = Request::try_parse(DATA).unwrap().unwrap();
         assert!(create_response(&req).is_ok());
     }
 }


### PR DESCRIPTION
The Connection header is matched token-wise (`split([' ', ',']).any(...)`) but the adjacent Upgrade check in `create_parts` and `verify_response` compares the whole value against "websocket". Upgrade is a comma-separated token list (RFC 7230 6.7), so a peer sending e.g. `Upgrade: websocket, h2c` is rejected with MissingUpgradeWebSocketHeader. Split into tokens before matching, same as the Connection check right next to it.