### PR TITLE
drop credentials when connect follows a cross-origin redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+* Drop sensitive headers (`Authorization`, `Cookie`, `Proxy-Authorization`, ...) when `connect` follows a redirect to a different origin.
+
 # 0.30.0
 
 * Reject non-compliant clients (incorrect `Sec-WebSocket-Key` length/format) on the server side.

--- a/src/client.rs
+++ b/src/client.rs
@@ -98,7 +98,13 @@ pub fn connect_with_config<Req: IntoClientRequest>(
                     if !is_same_origin(&uri, &new_uri) {
                         // Drop credentials when redirected to a different origin, otherwise
                         // a server can point us at an arbitrary host and harvest them.
-                        for header in ["authorization", "cookie", "proxy-authorization"] {
+                        for header in [
+                            "authorization",
+                            "cookie",
+                            "cookie2",
+                            "proxy-authorization",
+                            "www-authenticate",
+                        ] {
                             parts.headers.remove(header);
                         }
                     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -85,7 +85,7 @@ pub fn connect_with_config<Req: IntoClientRequest>(
         builder.body(()).expect("Failed to create `Request`")
     }
 
-    let (parts, _) = request.into_client_request()?.into_parts();
+    let (mut parts, _) = request.into_client_request()?.into_parts();
     let mut uri = parts.uri.clone();
 
     for attempt in 0..=max_redirects {
@@ -94,7 +94,15 @@ pub fn connect_with_config<Req: IntoClientRequest>(
         match try_client_handshake(request, config) {
             Err(Error::Http(res)) if res.status().is_redirection() && attempt < max_redirects => {
                 if let Some(location) = res.headers().get("Location") {
-                    uri = location.to_str()?.parse::<Uri>()?;
+                    let new_uri = location.to_str()?.parse::<Uri>()?;
+                    if !is_same_origin(&uri, &new_uri) {
+                        // Drop credentials when redirected to a different origin, otherwise
+                        // a server can point us at an arbitrary host and harvest them.
+                        for header in ["authorization", "cookie", "proxy-authorization"] {
+                            parts.headers.remove(header);
+                        }
+                    }
+                    uri = new_uri;
                     debug!("Redirecting to {uri:?}");
                     continue;
                 } else {
@@ -125,6 +133,19 @@ pub fn connect<Req: IntoClientRequest>(
     request: Req,
 ) -> Result<(WebSocket<MaybeTlsStream<TcpStream>>, Response)> {
     connect_with_config(request, None, 3)
+}
+
+/// Whether two URIs share the same origin (scheme, host and effective port).
+fn is_same_origin(a: &Uri, b: &Uri) -> bool {
+    fn port(uri: &Uri) -> Option<u16> {
+        uri.port_u16().or_else(|| match uri.scheme_str() {
+            Some("ws") => Some(80),
+            Some("wss") => Some(443),
+            _ => None,
+        })
+    }
+    let host = |uri: &Uri| uri.host().map(str::to_ascii_lowercase);
+    a.scheme_str() == b.scheme_str() && host(a) == host(b) && port(a) == port(b)
 }
 
 fn connect_to_some(addrs: &[SocketAddr], uri: &Uri) -> Result<TcpStream> {
@@ -339,5 +360,24 @@ impl IntoClientRequest for ClientRequestBuilder {
             headers.append("Sec-WebSocket-Protocol", protocols);
         }
         Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_same_origin;
+    use http::Uri;
+
+    #[test]
+    fn same_origin() {
+        let p = |s: &str| s.parse::<Uri>().unwrap();
+        assert!(is_same_origin(&p("ws://example.com/a"), &p("ws://example.com/b")));
+        assert!(is_same_origin(&p("ws://example.com/a"), &p("ws://EXAMPLE.com/b")));
+        assert!(is_same_origin(&p("ws://example.com:80/a"), &p("ws://example.com/b")));
+        assert!(is_same_origin(&p("wss://example.com:443/a"), &p("wss://example.com/b")));
+
+        assert!(!is_same_origin(&p("ws://example.com/a"), &p("ws://other.com/a")));
+        assert!(!is_same_origin(&p("ws://example.com/a"), &p("wss://example.com/a")));
+        assert!(!is_same_origin(&p("ws://example.com:80/a"), &p("ws://example.com:81/a")));
     }
 }

--- a/tests/redirect_credentials.rs
+++ b/tests/redirect_credentials.rs
@@ -1,0 +1,83 @@
+#![cfg(feature = "handshake")]
+#![allow(clippy::result_large_err)]
+
+use http::Uri;
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread::{sleep, spawn},
+    time::Duration,
+};
+use tungstenite::{
+    accept_hdr, connect,
+    handshake::server::{Request, Response},
+    ClientRequestBuilder,
+};
+
+/// A server that redirects the client to a different origin must not cause the
+/// originally supplied `Authorization` header to be forwarded to that origin.
+#[test]
+fn auth_header_dropped_on_cross_origin_redirect() {
+    let _ = env_logger::try_init();
+
+    spawn(|| {
+        sleep(Duration::from_secs(10));
+        eprintln!("Unit test executed too long, perhaps stuck on WOULDBLOCK...");
+        std::process::exit(1);
+    });
+
+    let redirector = TcpListener::bind("127.0.0.1:0").unwrap();
+    let target = TcpListener::bind("127.0.0.1:0").unwrap();
+    let redirector_port = redirector.local_addr().unwrap().port();
+    let target_port = target.local_addr().unwrap().port();
+
+    // First hop: answer the handshake with a redirect to a different port (origin).
+    let redirect_thread = spawn(move || {
+        let (mut sock, _) = redirector.accept().unwrap();
+        let mut buf = Vec::new();
+        let mut tmp = [0u8; 256];
+        loop {
+            let n = sock.read(&mut tmp).unwrap();
+            buf.extend_from_slice(&tmp[..n]);
+            if n == 0 || buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+        let resp = format!(
+            "HTTP/1.1 302 Found\r\nLocation: ws://127.0.0.1:{target_port}/\r\nContent-Length: 0\r\n\r\n"
+        );
+        sock.write_all(resp.as_bytes()).unwrap();
+        sock.flush().unwrap();
+    });
+
+    // Second hop: the redirect target records whether it saw the credential.
+    let leaked = Arc::new(AtomicBool::new(false));
+    let leaked_server = leaked.clone();
+    let target_thread = spawn(move || {
+        let (stream, _) = target.accept().unwrap();
+        let callback = |req: &Request, response: Response| {
+            if req.headers().get("authorization").is_some() {
+                leaked_server.store(true, Ordering::SeqCst);
+            }
+            Ok(response)
+        };
+        let mut ws = accept_hdr(stream, callback).unwrap();
+        let _ = ws.read();
+    });
+
+    let uri: Uri = format!("ws://127.0.0.1:{redirector_port}/").parse().unwrap();
+    let builder =
+        ClientRequestBuilder::new(uri).with_header("Authorization", "Bearer super-secret-token");
+
+    let (client, _) = connect(builder).unwrap();
+    drop(client);
+
+    redirect_thread.join().unwrap();
+    target_thread.join().unwrap();
+
+    assert!(!leaked.load(Ordering::SeqCst), "Authorization header leaked to redirect target");
+}


### PR DESCRIPTION
**Credentials forwarded across origins on redirect**

`connect` follows redirects by replaying the original request on every hop, so an `Authorization` or `Cookie` set on the initial request is sent to whatever host the server puts in `Location`. A malicious or compromised endpoint can redirect to an origin it shouldn't have the credentials for and harvest them, so I drop those headers (and `Proxy-Authorization`) when the redirect target's scheme, host or port differ from the current one. Regression test in tests/redirect_credentials.rs.