### PR TITLE
Replace runtime rand dependency with getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bytes = "1.9.0"
 http = { version = "1.0", optional = true }
 httparse = { version = "1.3.4", optional = true }
 log = "0.4.8"
-rand = "0.9.0"
+getrandom = "0.3"
 sha1 = { version = "0.10", optional = true }
 thiserror = "2.0.7"
 url = { version = "2.1.0", optional = true }

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -329,8 +329,9 @@ impl<'h, 'b: 'h> FromHttparse<httparse::Response<'h, 'b>> for Response {
 pub fn generate_key() -> String {
     // a base64-encoded (see Section 4 of [RFC4648]) value that,
     // when decoded, is 16 bytes in length (RFC 6455)
-    let r: [u8; 16] = rand::random();
-    data_encoding::BASE64.encode(&r)
+    let mut key = [0u8; 16];
+    getrandom::fill(&mut key).expect("websocket handshake key requires system randomness");
+    data_encoding::BASE64.encode(&key)
 }
 
 #[cfg(test)]

--- a/src/protocol/frame/mask.rs
+++ b/src/protocol/frame/mask.rs
@@ -1,7 +1,9 @@
 /// Generate a random frame mask.
 #[inline]
 pub fn generate_mask() -> [u8; 4] {
-    rand::random()
+    let mut mask = [0u8; 4];
+    getrandom::fill(&mut mask).expect("websocket mask generation requires system randomness");
+    mask
 }
 
 /// Mask/unmask a frame.


### PR DESCRIPTION
## Summary

This removes the runtime `rand` dependency from tungstenite and uses `getrandom` directly for the two protocol entropy call sites:

- WebSocket client masking keys (`[u8; 4]`)
- `Sec-WebSocket-Key` generation during client handshakes (`[u8; 16]`)

The generated byte lengths and public API stay unchanged. The existing `rand` dev-dependency remains in place for benchmarks.

I used `getrandom = "0.3"` so the change stays within the repository's Rust 1.71 MSRV while avoiding the heavier runtime `rand` dependency for these byte-fill operations.

## Tradeoffs

The current APIs are infallible, so this keeps that shape and treats system entropy failure as unrecoverable with explicit `expect(...)` messages. Changing these call sites to return `Result` would be a wider public API change and does not seem warranted for this dependency cleanup.

## Verification

- `RUSTUP_HOME=/Volumes/wd_black/rustup-home CARGO_HOME=/Volumes/wd_black/cargo-home rustup run nightly cargo fmt --all --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/tungstenite cargo clippy --all --tests --all-features -- -D warnings`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/tungstenite cargo test --release`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/tungstenite RUSTUP_HOME=/Volumes/wd_black/rustup-home CARGO_HOME=/Volumes/wd_black/cargo-home rustup run 1.71.1 cargo check`
- `PATH=/Volumes/wd_black/cargo-home/bin:$PATH CARGO_HOME=/Volumes/wd_black/cargo-home CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/tungstenite cargo hack check --feature-powerset --all-targets`

Note: `cargo fmt` reports existing warnings about unstable rustfmt config options, but exits successfully.
