### PR TITLE
Add WebSocket::into_inner_with_read_buffer to recover buffered bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 * Reject non-compliant clients (incorrect `Sec-WebSocket-Key` length/format) on the server side.
+* Add `WebSocket::into_inner_with_read_buffer()` (and `WebSocketContext::into_read_buffer()`) so that a caller taking over the raw stream after the handshake can recover bytes the peer coalesced into the same read as the handshake response, which `into_inner()` discards.
 
 # 0.29.0
 

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -148,7 +148,19 @@ impl FrameCodec {
 
     /// Consume the codec, returning the bytes that were read from the stream
     /// into the read buffer but not yet consumed as a frame.
+    ///
+    /// Lossless only at a frame boundary. If a partial frame is in flight (a
+    /// header has been parsed but its payload has not fully arrived, e.g. after
+    /// a mid-frame `WouldBlock`), the header bytes have already been consumed
+    /// out of the read buffer and are not recoverable here — the returned
+    /// buffer then holds only the partial payload. Debug builds assert against
+    /// this misuse.
     pub(super) fn into_read_buffer(self) -> BytesMut {
+        debug_assert!(
+            self.header.is_none(),
+            "into_read_buffer called with a partial frame in flight; the parsed \
+             header bytes have already been consumed and cannot be recovered",
+        );
         self.in_buffer
     }
 

--- a/src/protocol/frame/mod.rs
+++ b/src/protocol/frame/mod.rs
@@ -146,6 +146,12 @@ impl FrameCodec {
         }
     }
 
+    /// Consume the codec, returning the bytes that were read from the stream
+    /// into the read buffer but not yet consumed as a frame.
+    pub(super) fn into_read_buffer(self) -> BytesMut {
+        self.in_buffer
+    }
+
     /// Sets a maximum size for the out buffer.
     pub(super) fn set_max_out_buffer_len(&mut self, max: usize) {
         self.max_out_buffer_len = max;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     error::{CapacityError, Error, ProtocolError, Result},
     protocol::frame::Utf8Bytes,
 };
+use bytes::Bytes;
 use log::*;
 use std::{
     io::{self, Read, Write},
@@ -202,6 +203,21 @@ impl<Stream> WebSocket<Stream> {
     /// Consumes the `WebSocket` and returns the underlying stream.
     pub fn into_inner(self) -> Stream {
         self.socket
+    }
+
+    /// Consumes the `WebSocket` and returns the underlying stream together with
+    /// any bytes that were already read from it into the internal read buffer
+    /// but not yet consumed as a WebSocket message.
+    ///
+    /// Unlike [`WebSocket::into_inner`], this does not discard that buffered
+    /// data. It is useful when taking ownership of the raw stream after the
+    /// handshake — for example to relay raw bytes — where the peer may have
+    /// coalesced WebSocket frame bytes into the same read as the handshake
+    /// response (or where some frames have already been read and a tail
+    /// remains). Those buffered bytes precede anything still unread on the
+    /// returned stream.
+    pub fn into_inner_with_read_buffer(self) -> (Stream, Bytes) {
+        (self.socket, self.context.into_read_buffer())
     }
 
     /// Returns a shared reference to the inner stream.
@@ -425,6 +441,19 @@ impl WebSocketContext {
     /// Read the configuration.
     pub fn get_config(&self) -> &WebSocketConfig {
         &self.config
+    }
+
+    /// Consume the context, returning the bytes that were read from the stream
+    /// into the internal read buffer but not yet consumed as a WebSocket
+    /// message.
+    ///
+    /// This is the counterpart to [`WebSocket::into_inner_with_read_buffer`] for
+    /// callers that drive [`WebSocketContext`] over their own stream: it lets
+    /// them recover any buffered-but-unconsumed bytes (e.g. frame bytes the peer
+    /// coalesced into the same read as the handshake response) before taking the
+    /// raw stream over.
+    pub fn into_read_buffer(self) -> Bytes {
+        self.frame.into_read_buffer().freeze()
     }
 
     /// Check if it is possible to read messages.
@@ -910,5 +939,41 @@ mod tests {
             socket.read(),
             Err(Error::Capacity(CapacityError::MessageTooLong { size: 3, max_size: 2 }))
         ));
+    }
+
+    #[test]
+    fn into_inner_with_read_buffer_recovers_coalesced_bytes() {
+        // A server may coalesce WebSocket frame bytes into the same read as the
+        // handshake response; `from_partially_read` models that by seeding the
+        // codec's read buffer. Those bytes must survive a raw takeover of the
+        // stream — `into_inner` discards them, `into_inner_with_read_buffer`
+        // returns them.
+        let coalesced = vec![0x82, 0x03, 0x01, 0x02, 0x03];
+        let ws = WebSocket::from_partially_read(
+            WriteMoc(Cursor::new(Vec::<u8>::new())),
+            coalesced.clone(),
+            Role::Client,
+            None,
+        );
+        let (_stream, buffer) = ws.into_inner_with_read_buffer();
+        assert_eq!(&buffer[..], &coalesced[..]);
+    }
+
+    #[test]
+    fn into_inner_with_read_buffer_returns_unread_tail() {
+        // Two frames arrive buffered together; after reading the first, the
+        // second remains in the read buffer and must be recoverable for a raw
+        // takeover.
+        let mut framed = vec![0x82, 0x01, 0x41]; // binary "A"
+        framed.extend_from_slice(&[0x82, 0x01, 0x42]); // binary "B"
+        let mut ws = WebSocket::from_partially_read(
+            WriteMoc(Cursor::new(Vec::<u8>::new())),
+            framed,
+            Role::Client,
+            None,
+        );
+        assert_eq!(ws.read().unwrap(), Message::Binary(vec![0x41].into()));
+        let (_stream, buffer) = ws.into_inner_with_read_buffer();
+        assert_eq!(&buffer[..], &[0x82, 0x01, 0x42]);
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -216,6 +216,18 @@ impl<Stream> WebSocket<Stream> {
     /// response (or where some frames have already been read and a tail
     /// remains). Those buffered bytes precede anything still unread on the
     /// returned stream.
+    ///
+    /// # Frame boundary
+    ///
+    /// This is lossless only at a frame boundary: before any message has been
+    /// read, or after whole messages have been read. If a frame is only
+    /// partially read — its header has been parsed but the payload has not
+    /// fully arrived, e.g. after a mid-frame
+    /// [`WouldBlock`](std::io::ErrorKind::WouldBlock) — the already-parsed
+    /// header bytes have been consumed from the read buffer and cannot be
+    /// recovered; only the partial payload would be returned. The intended use,
+    /// taking over the raw stream right after the handshake, is always at a
+    /// frame boundary. Debug builds assert this precondition.
     pub fn into_inner_with_read_buffer(self) -> (Stream, Bytes) {
         (self.socket, self.context.into_read_buffer())
     }
@@ -452,6 +464,11 @@ impl WebSocketContext {
     /// them recover any buffered-but-unconsumed bytes (e.g. frame bytes the peer
     /// coalesced into the same read as the handshake response) before taking the
     /// raw stream over.
+    ///
+    /// Like [`WebSocket::into_inner_with_read_buffer`], this is lossless only at
+    /// a frame boundary; if a frame is only partially read, its already-parsed
+    /// header bytes are not recoverable and only the partial payload is
+    /// returned.
     pub fn into_read_buffer(self) -> Bytes {
         self.frame.into_read_buffer().freeze()
     }
@@ -975,5 +992,36 @@ mod tests {
         assert_eq!(ws.read().unwrap(), Message::Binary(vec![0x41].into()));
         let (_stream, buffer) = ws.into_inner_with_read_buffer();
         assert_eq!(&buffer[..], &[0x82, 0x01, 0x42]);
+    }
+
+    // The lossless guarantee holds only at a frame boundary. With a header
+    // parsed but its payload incomplete, the header bytes have already left the
+    // read buffer; recovering it then would silently drop them, so debug builds
+    // assert against the call. Only meaningful with debug assertions enabled.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "partial frame")]
+    fn into_inner_with_read_buffer_panics_mid_frame_in_debug() {
+        // A read end that always reports "no data yet", so a frame can be left
+        // half-read (header parsed, payload incomplete) deterministically.
+        struct WouldBlockRead;
+        impl io::Read for WouldBlockRead {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::WouldBlock, "would block"))
+            }
+        }
+
+        // Header for a 5-byte binary frame, but only 2 payload bytes buffered;
+        // the stream then yields WouldBlock, leaving a parsed header whose
+        // payload is incomplete.
+        let partial = vec![0x82, 0x05, 0x01, 0x02];
+        let mut ws =
+            WebSocket::from_partially_read(WriteMoc(WouldBlockRead), partial, Role::Client, None);
+        assert!(matches!(
+            ws.read(),
+            Err(Error::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock
+        ));
+        // Mid-frame: must not silently return a buffer missing the header bytes.
+        let _ = ws.into_inner_with_read_buffer();
     }
 }


### PR DESCRIPTION
Fixes #555.

### Problem

`WebSocket::into_inner()` returns only the underlying stream and discards the frame codec's internal read buffer. When a caller takes over the raw stream after the handshake (e.g. to relay raw bytes / drop to a plain byte copy), bytes the peer coalesced into the same read as the handshake response — or an unread frame tail — are silently lost. The codec's `in_buffer` is unreachable: it sits behind the private `WebSocketContext.frame` field inside the private `WebSocket.context`, and only `FrameSocket` (not the `WebSocket` path) exposes `into_inner() -> (Stream, BytesMut)`.

### Change

Add a consuming accessor that returns the stream together with its not-yet-consumed read buffer:

- `WebSocket::into_inner_with_read_buffer(self) -> (Stream, Bytes)`
- `WebSocketContext::into_read_buffer(self) -> Bytes` (counterpart for callers driving `WebSocketContext` over their own stream)
- `FrameCodec::into_read_buffer(self) -> BytesMut` (internal, `pub(super)`)

`Bytes` is already re-exported by the crate (`pub use bytes::Bytes`, used by `Message`), and `BytesMut::freeze()` is zero-copy, so this adds no new public dependency and no allocation. `into_inner()` is unchanged.

### Tests

- `into_inner_with_read_buffer_recovers_coalesced_bytes` — frame bytes seeded via `from_partially_read` (modelling a coalesced post-handshake segment) are returned, not dropped.
- `into_inner_with_read_buffer_returns_unread_tail` — after reading the first of two buffered frames, the second remains and is recovered.

Full lib test suite passes (50/50); `cargo fmt` and `cargo clippy --lib` are clean. CHANGELOG updated under UNRELEASED.

### Motivation

This is the upstream blocker for a lossless raw-stream takeover after a WebSocket handshake — e.g. a proxy/gateway tunnel mode that completes the handshake with tungstenite/tokio-tungstenite then bypasses framing to relay raw bytes. A companion PR on snapview/tokio-tungstenite surfaces this on `WebSocketStream`.