### PR TITLE
Don't panic on interrupted native-tls TLS handshake (#450)

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -14,7 +14,7 @@ use std::{
 use std::net::TcpStream;
 
 #[cfg(feature = "native-tls")]
-use native_tls_crate::TlsStream;
+use native_tls_crate::{HandshakeError as NativeHandshakeError, MidHandshakeTlsStream, TlsStream};
 #[cfg(feature = "__rustls-tls")]
 use rustls::StreamOwned;
 
@@ -46,6 +46,152 @@ impl<S: Read + Write + NoDelay> NoDelay for TlsStream<S> {
     }
 }
 
+/// A `native-tls` stream that may still be completing its TLS handshake.
+///
+/// The `native-tls` `TlsConnector::connect` drives the TLS handshake eagerly,
+/// so on a non-blocking transport it can return before the handshake is
+/// finished. This wrapper stores that mid-handshake state and transparently
+/// resumes it on the next read or write, mirroring the way the `rustls` backend
+/// defers its handshake until the first I/O operation. Keeping the two backends
+/// symmetric means an interrupted handshake surfaces as
+/// [`HandshakeError::Interrupted`](crate::HandshakeError::Interrupted) instead
+/// of panicking (see <https://github.com/snapview/tungstenite-rs/issues/450>).
+#[cfg(feature = "native-tls")]
+pub struct NativeTlsStream<S: Read + Write> {
+    state: NativeTlsState<S>,
+}
+
+#[cfg(feature = "native-tls")]
+#[allow(clippy::large_enum_variant)]
+enum NativeTlsState<S: Read + Write> {
+    /// The TLS handshake is still in progress; it is resumed on the next I/O.
+    Handshaking(MidHandshakeTlsStream<S>),
+    /// The TLS handshake has completed; I/O is delegated to the stream.
+    Ready(TlsStream<S>),
+    /// Transient placeholder used while resuming the handshake, and the terminal
+    /// state after a fatal handshake error. Any I/O in this state fails.
+    Invalid,
+}
+
+#[cfg(feature = "native-tls")]
+impl<S: Read + Write> NativeTlsStream<S> {
+    /// Wrap an already-completed `native-tls` stream.
+    pub(crate) fn ready(stream: TlsStream<S>) -> Self {
+        Self { state: NativeTlsState::Ready(stream) }
+    }
+
+    /// Wrap a `native-tls` stream whose handshake was interrupted (would block).
+    pub(crate) fn handshaking(stream: MidHandshakeTlsStream<S>) -> Self {
+        Self { state: NativeTlsState::Handshaking(stream) }
+    }
+
+    /// Returns a reference to the underlying `native-tls` stream, or `None` if
+    /// the TLS handshake has not finished yet.
+    pub fn get_ref(&self) -> Option<&TlsStream<S>> {
+        match &self.state {
+            NativeTlsState::Ready(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Returns a mutable reference to the underlying `native-tls` stream, or
+    /// `None` if the TLS handshake has not finished yet.
+    pub fn get_mut(&mut self) -> Option<&mut TlsStream<S>> {
+        match &mut self.state {
+            NativeTlsState::Ready(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Consumes the wrapper, returning the underlying `native-tls` stream, or
+    /// `None` if the TLS handshake has not finished yet.
+    pub fn into_inner(self) -> Option<TlsStream<S>> {
+        match self.state {
+            NativeTlsState::Ready(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Drive the handshake to completion if it is still pending. Returns `Ok`
+    /// once the stream is ready for I/O. If the handshake would block, the
+    /// mid-handshake state is kept so the operation can be retried later.
+    fn resume(&mut self) -> IoResult<()> {
+        if let NativeTlsState::Ready(_) = self.state {
+            return Ok(());
+        }
+        match std::mem::replace(&mut self.state, NativeTlsState::Invalid) {
+            NativeTlsState::Handshaking(mid) => match mid.handshake() {
+                Ok(stream) => {
+                    self.state = NativeTlsState::Ready(stream);
+                    Ok(())
+                }
+                Err(NativeHandshakeError::WouldBlock(mid)) => {
+                    self.state = NativeTlsState::Handshaking(mid);
+                    Err(std::io::ErrorKind::WouldBlock.into())
+                }
+                Err(NativeHandshakeError::Failure(err)) => Err(std::io::Error::other(err)),
+            },
+            // `Ready` is handled above, so only `Invalid` reaches this arm.
+            _ => Err(std::io::Error::other("native-tls stream used after a failed handshake")),
+        }
+    }
+}
+
+#[cfg(feature = "native-tls")]
+impl<S: Read + Write + Debug> Debug for NativeTlsStream<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.state {
+            NativeTlsState::Handshaking(_) => {
+                f.debug_tuple("NativeTlsStream::Handshaking").finish()
+            }
+            NativeTlsState::Ready(s) => f.debug_tuple("NativeTlsStream::Ready").field(s).finish(),
+            NativeTlsState::Invalid => f.debug_tuple("NativeTlsStream::Invalid").finish(),
+        }
+    }
+}
+
+#[cfg(feature = "native-tls")]
+impl<S: Read + Write> Read for NativeTlsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        self.resume()?;
+        match &mut self.state {
+            NativeTlsState::Ready(s) => s.read(buf),
+            // `resume` only returns `Ok` when the stream is `Ready`.
+            _ => Err(std::io::ErrorKind::WouldBlock.into()),
+        }
+    }
+}
+
+#[cfg(feature = "native-tls")]
+impl<S: Read + Write> Write for NativeTlsStream<S> {
+    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+        self.resume()?;
+        match &mut self.state {
+            NativeTlsState::Ready(s) => s.write(buf),
+            _ => Err(std::io::ErrorKind::WouldBlock.into()),
+        }
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        self.resume()?;
+        match &mut self.state {
+            NativeTlsState::Ready(s) => s.flush(),
+            _ => Err(std::io::ErrorKind::WouldBlock.into()),
+        }
+    }
+}
+
+#[cfg(feature = "native-tls")]
+impl<S: Read + Write + NoDelay> NoDelay for NativeTlsStream<S> {
+    fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
+        match &mut self.state {
+            NativeTlsState::Handshaking(mid) => mid.get_mut().set_nodelay(nodelay),
+            NativeTlsState::Ready(s) => s.get_mut().set_nodelay(nodelay),
+            NativeTlsState::Invalid => Ok(()),
+        }
+    }
+}
+
 #[cfg(feature = "__rustls-tls")]
 impl<S, SD, T> NoDelay for StreamOwned<S, T>
 where
@@ -66,7 +212,7 @@ pub enum MaybeTlsStream<S: Read + Write> {
     Plain(S),
     #[cfg(feature = "native-tls")]
     /// Encrypted socket stream using `native-tls`.
-    NativeTls(native_tls_crate::TlsStream<S>),
+    NativeTls(NativeTlsStream<S>),
     #[cfg(feature = "__rustls-tls")]
     /// Encrypted socket stream using `rustls`.
     Rustls(rustls::StreamOwned<rustls::ClientConnection, S>),

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -35,7 +35,7 @@ mod encryption {
 
         use crate::{
             error::TlsError,
-            stream::{MaybeTlsStream, Mode},
+            stream::{MaybeTlsStream, Mode, NativeTlsStream},
             Error, Result,
         };
 
@@ -55,13 +55,15 @@ mod encryption {
                     let connector = try_connector.map_err(TlsError::from)?;
                     let connected = connector.connect(domain, socket);
                     match connected {
-                        Err(e) => match e {
-                            TlsHandshakeError::Failure(f) => Err(Error::Tls(f.into())),
-                            TlsHandshakeError::WouldBlock(_) => {
-                                panic!("Bug: TLS handshake not blocked")
-                            }
-                        },
-                        Ok(s) => Ok(MaybeTlsStream::NativeTls(s)),
+                        Ok(s) => Ok(MaybeTlsStream::NativeTls(NativeTlsStream::ready(s))),
+                        Err(TlsHandshakeError::Failure(f)) => Err(Error::Tls(f.into())),
+                        // A non-blocking transport can interrupt the handshake.
+                        // Preserve the mid-handshake state so it can be resumed
+                        // on the next I/O attempt (symmetric to the rustls
+                        // backend) instead of panicking. See issue #450.
+                        Err(TlsHandshakeError::WouldBlock(mid)) => {
+                            Ok(MaybeTlsStream::NativeTls(NativeTlsStream::handshaking(mid)))
+                        }
                     }
                 }
             }

--- a/tests/native_tls_wouldblock.rs
+++ b/tests/native_tls_wouldblock.rs
@@ -1,0 +1,62 @@
+//! Regression test for https://github.com/snapview/tungstenite-rs/issues/450
+//!
+//! A non-blocking stream that reports `WouldBlock` mid TLS handshake must not
+//! crash the process. The native-tls backend used to `panic!("Bug: TLS
+//! handshake not blocked")`; it must instead surface the interruption as
+//! `HandshakeError::Interrupted`, symmetric to the rustls backend, so the
+//! caller can retry once the transport is ready.
+#![cfg(feature = "native-tls")]
+
+use std::io::{self, Read, Write};
+
+use tungstenite::{client_tls, stream::MaybeTlsStream, HandshakeError};
+
+/// A stream that always reports `WouldBlock` on read and silently accepts
+/// writes, simulating a non-blocking socket that is still mid TLS handshake.
+struct WouldBlockStream;
+
+impl Read for WouldBlockStream {
+    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::from(io::ErrorKind::WouldBlock))
+    }
+}
+
+impl Write for WouldBlockStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn native_tls_handshake_wouldblock_is_interrupted_not_panic() {
+    // Before the fix this panics with "Bug: TLS handshake not blocked".
+    // After the fix the interrupted handshake is reported the same way the
+    // rustls backend reports it: `HandshakeError::Interrupted`, which lets the
+    // caller retry once the transport is ready again.
+    let result = client_tls("wss://example.com/socket", WouldBlockStream);
+    match result {
+        Err(HandshakeError::Interrupted(_)) => {}
+        Err(other) => panic!("expected HandshakeError::Interrupted, got: {other:?}"),
+        Ok(_) => panic!("handshake unexpectedly succeeded over a would-block stream"),
+    }
+}
+
+#[test]
+fn native_tls_handshake_wouldblock_inner_stream_is_none_mid_handshake() {
+    // While the TLS handshake is still pending, the wrapper exposes no
+    // completed `native_tls::TlsStream` yet.
+    match client_tls("wss://example.com/socket", WouldBlockStream) {
+        Err(HandshakeError::Interrupted(mid)) => match mid.get_ref().get_ref() {
+            MaybeTlsStream::NativeTls(native) => {
+                assert!(native.get_ref().is_none(), "TlsStream must be None mid-handshake");
+            }
+            _ => panic!("expected the native-tls stream variant"),
+        },
+        Err(other) => panic!("expected HandshakeError::Interrupted, got: {other:?}"),
+        Ok(_) => panic!("handshake unexpectedly succeeded over a would-block stream"),
+    }
+}


### PR DESCRIPTION
Fixes #450

## Problem

With the `native-tls` backend, establishing a `wss://` connection over a
non-blocking transport can crash the whole process. When the underlying
`Read + Write` stream returns `WouldBlock` (or a dropped connection) partway
through the TLS handshake, tungstenite hits:

```
thread '...' panicked at src/tls.rs:61:
Bug: TLS handshake not blocked
```

This makes it impossible to drive the client handshake on a non-blocking
socket and retry — the exact use case `HandshakeError::Interrupted` exists for.
The `rustls` backend does **not** have this problem, so the two backends behave
asymmetrically for the same input.

## Root cause

`src/tls.rs`, `encryption::native_tls::wrap_stream` (line 60-62 on `master`):

```rust
TlsHandshakeError::WouldBlock(_) => {
    panic!("Bug: TLS handshake not blocked")
}
```

`native_tls::TlsConnector::connect` drives the TLS handshake *eagerly*, so on a
non-blocking transport it legitimately returns
`native_tls::HandshakeError::WouldBlock(MidHandshakeTlsStream)`. The code
assumed this could never happen and panicked instead of handling it.

The `rustls` backend avoids the whole situation because it never runs the
handshake inside `wrap_stream`: it wraps the socket in a `rustls::StreamOwned`
and lets the TLS handshake complete *lazily* on the first read/write. The
resulting `WouldBlock` then flows through the normal handshake machine and
becomes `HandshakeError::Interrupted`.

## Fix

Mirror the rustls semantics for native-tls, as suggested by @daniel-abramov in
the issue ("wrap the type that native-tls contains so that handling of the TLS
handshake with native-tls remains identical to the end user").

A small wrapper type `stream::NativeTlsStream<S>` now holds either the completed
`native_tls::TlsStream<S>` or the interrupted `MidHandshakeTlsStream<S>`, and
resumes the handshake transparently on the next `read`/`write`:

- `wrap_stream` stores the mid-handshake stream instead of panicking.
- On the next I/O attempt the wrapper calls `MidHandshakeTlsStream::handshake()`.
  If it would block again, it keeps the mid-handshake state and returns
  `io::ErrorKind::WouldBlock`; once complete it transitions to the ready state
  and delegates I/O to the `TlsStream`.

Because the first thing the WebSocket client handshake does is *write* the
upgrade request, that `WouldBlock` is turned by the handshake machine into
`RoundResult::WouldBlock` → `HandshakeError::Interrupted(MidHandshake { .. })` —
**identical to the rustls backend**. The caller can then call `.handshake()`
again to retry, and the resume logic continues the TLS handshake from where it
left off.

Blocking callers are unaffected: `connect` completes eagerly, the wrapper starts
in the `Ready` state, and every I/O call delegates straight to the inner
`TlsStream` (one extra enum branch, no behavioural change).

Files changed:
- `src/tls.rs` — convert the panic into the interrupted/ready paths.
- `src/stream.rs` — add `NativeTlsStream` wrapper (Read/Write/Debug/NoDelay,
  plus `get_ref`/`get_mut`/`into_inner` accessors) and change the
  `MaybeTlsStream::NativeTls` payload to it.
- `tests/native_tls_wouldblock.rs` — regression tests.

## Test

`tests/native_tls_wouldblock.rs` feeds `client_tls` a mock stream whose `read`
always returns `WouldBlock` (writes are accepted), reproducing the reporter's
scenario deterministically. One test asserts the result is
`HandshakeError::Interrupted`; a second asserts `NativeTlsStream::get_ref()`
returns `None` while the handshake is still pending.

**Before the fix** (only `src/` reverted to base, test kept):

```
thread 'native_tls_handshake_wouldblock_is_interrupted_not_panic' panicked at src/tls.rs:61:33:
Bug: TLS handshake not blocked
test native_tls_handshake_wouldblock_is_interrupted_not_panic ... FAILED
test result: FAILED. 0 passed; 1 failed; ...
```

**After the fix:**

```
test native_tls_handshake_wouldblock_is_interrupted_not_panic ... ok
test result: ok. 1 passed; 0 failed; ...
```

## Verification

All commands run on macOS (native-tls = Secure Transport); toolchain 1.96.0,
nightly rustfmt as used by CI.

```
# Full native-tls suite (48 unit tests + integration incl. the regression) — PASS
cargo test --features native-tls
    test result: ok. 48 passed; 0 failed  (lib)
    test native_tls_handshake_wouldblock_is_interrupted_not_panic ... ok

# Default features (no TLS) — PASS (also confirms the fix compiles without native-tls)
cargo test

# Formatting — clean
cargo +nightly fmt --all --check

# Lints, all features (native-tls + rustls together), warnings-as-errors — clean
cargo clippy --all --tests --all-features -- -D warnings

# Feature-gating sanity — both succeed
cargo check --no-default-features
cargo check --features rustls-tls-webpki-roots
```

## Compatibility

This is a **semver-breaking** change to one public type: the payload of
`MaybeTlsStream::NativeTls` changes from `native_tls::TlsStream<S>` to
`stream::NativeTlsStream<S>`. Code that pattern-matches that variant and uses
the inner value as a `native_tls::TlsStream` will need to adapt.
`NativeTlsStream<S>` implements `Read`, `Write`, `Debug` and `NoDelay`, so most
usage through `MaybeTlsStream` is unaffected. To preserve access to the
underlying `native_tls::TlsStream` (e.g. `peer_certificate()`), it also exposes
`get_ref()`, `get_mut()` and `into_inner()`, each returning `Some(..)` once the
handshake has completed and `None` while it is still pending. This matches the
"wrap the type that native-tls contains" direction from the issue. No
`CHANGELOG.md` entry was added since there is no "Unreleased" section yet — glad
to add one under whatever next version you'd like.
